### PR TITLE
Mesh refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ gui           ?= 0
 ipstools      ?= 0
 inst_hex_name ?= stim_instr.txt 
 data_hex_name ?= stim_data.txt 
-inst_entry    ?= 0x2C000000
-data_entry    ?= 0x2c010000
-boot_addr     ?= 0x2c000080
+inst_entry    ?= 0x5C000000
+data_entry    ?= 0x5c010000
+boot_addr     ?= 0x5c000080
 # Add here a path to the core traces of each tile you want to monitor
 log_path_0    ?= ./core_0_traces.log
 log_path_1    ?= ./core_1_traces.log

--- a/hw/mesh/redmule_mesh_pkg.sv
+++ b/hw/mesh/redmule_mesh_pkg.sv
@@ -47,4 +47,22 @@ package redmule_mesh_pkg;
   `AXI_ALIAS(noc_axi_data, axi_xbar_mst, noc_axi_data_req_t, axi_xbar_mst_req_t, noc_axi_data_rsp_t, axi_xbar_mst_rsp_t)
   `AXI_ALIAS(noc_axi_data, axi_default, noc_axi_data_req_t, axi_default_req_t, noc_axi_data_rsp_t, axi_default_rsp_t)
 
+  typedef axi_pkg::xbar_rule_32_t mesh_xbar_rule_t;
+
+  localparam axi_pkg::xbar_cfg_t mesh_xbar_cfg = '{
+    NoSlvPorts          : 4,    // redmule_mesh_tb_pkg::N_TILES,
+    NoMstPorts          : 5,    // redmule_mesh_tb_pkg::N_TILES + 1,
+    MaxMstTrans         : 64,   // redmule_tile_pkg::AxiXbarMaxWTrans*4
+    MaxSlvTrans         : 64,
+    FallThrough         : 1'b0,
+    LatencyMode         : axi_pkg::CUT_ALL_PORTS,
+    PipelineStages      : '0,   // TODO: make it parametric
+    AxiIdWidthSlvPorts  : AXI_NOC_ID_W,
+    AxiIdUsedSlvPorts   : AXI_NOC_ID_W, // check me!
+    UniqueIds           : 1'b0,
+    AxiAddrWidth        : ADDR_W,
+    AxiDataWidth        : DATA_W,
+    NoAddrRules         : 5    // redmule_mesh_tb_pkg::N_TILES + 1
+  };
+
 endpackage: redmule_mesh_pkg

--- a/hw/mesh/redmule_mesh_pkg.sv
+++ b/hw/mesh/redmule_mesh_pkg.sv
@@ -53,19 +53,19 @@ package redmule_mesh_pkg;
   typedef axi_pkg::xbar_rule_32_t mesh_xbar_rule_t;
 
   localparam axi_pkg::xbar_cfg_t mesh_xbar_cfg = '{
-    NoSlvPorts          : 4,    // redmule_mesh_tb_pkg::N_TILES,
-    NoMstPorts          : 5,    // redmule_mesh_tb_pkg::N_TILES + 1,
-    MaxMstTrans         : 64,   // redmule_tile_pkg::AxiXbarMaxWTrans*4
+    NoSlvPorts          : 4,    // TODO: redmule_mesh_tb_pkg::N_TILES,
+    NoMstPorts          : 5,    // TODO: redmule_mesh_tb_pkg::N_TILES + 1,
+    MaxMstTrans         : 64,   // TODO: redmule_tile_pkg::AxiXbarMaxWTrans*4
     MaxSlvTrans         : 64,
     FallThrough         : 1'b0,
     LatencyMode         : axi_pkg::CUT_ALL_PORTS,
     PipelineStages      : '0,   // TODO: make it parametric
     AxiIdWidthSlvPorts  : AXI_NOC_ID_W,
-    AxiIdUsedSlvPorts   : AXI_NOC_ID_W, // check me!
+    AxiIdUsedSlvPorts   : AXI_NOC_ID_W, // TODO: check me!
     UniqueIds           : 1'b0,
     AxiAddrWidth        : ADDR_W,
     AxiDataWidth        : DATA_W,
-    NoAddrRules         : 5    // redmule_mesh_tb_pkg::N_TILES + 1
+    NoAddrRules         : 5    // TODO: redmule_mesh_tb_pkg::N_TILES + 1
   };
 
 endpackage: redmule_mesh_pkg

--- a/hw/mesh/redmule_mesh_pkg.sv
+++ b/hw/mesh/redmule_mesh_pkg.sv
@@ -50,4 +50,22 @@ package redmule_mesh_pkg;
   `AXI_ALIAS(noc_axi_data, axi_xbar_mst, noc_axi_data_req_t, axi_xbar_mst_req_t, noc_axi_data_rsp_t, axi_xbar_mst_rsp_t)
   `AXI_ALIAS(noc_axi_data, axi_default, noc_axi_data_req_t, axi_default_req_t, noc_axi_data_rsp_t, axi_default_rsp_t)
 
+  typedef axi_pkg::xbar_rule_32_t mesh_xbar_rule_t;
+
+  localparam axi_pkg::xbar_cfg_t mesh_xbar_cfg = '{
+    NoSlvPorts          : 4,    // redmule_mesh_tb_pkg::N_TILES,
+    NoMstPorts          : 5,    // redmule_mesh_tb_pkg::N_TILES + 1,
+    MaxMstTrans         : 64,   // redmule_tile_pkg::AxiXbarMaxWTrans*4
+    MaxSlvTrans         : 64,
+    FallThrough         : 1'b0,
+    LatencyMode         : axi_pkg::CUT_ALL_PORTS,
+    PipelineStages      : '0,   // TODO: make it parametric
+    AxiIdWidthSlvPorts  : AXI_NOC_ID_W,
+    AxiIdUsedSlvPorts   : AXI_NOC_ID_W, // check me!
+    UniqueIds           : 1'b0,
+    AxiAddrWidth        : ADDR_W,
+    AxiDataWidth        : DATA_W,
+    NoAddrRules         : 5    // redmule_mesh_tb_pkg::N_TILES + 1
+  };
+
 endpackage: redmule_mesh_pkg

--- a/hw/tile/redmule_tile.sv
+++ b/hw/tile/redmule_tile.sv
@@ -200,8 +200,9 @@ module redmule_tile
 /**            Hardwired Signals Beginning            **/
 /*******************************************************/
 
-  assign obi_xbar_rule[redmule_tile_pkg::L2_IDX]    = '{idx: 32'd0, start_addr: redmule_tile_pkg::L2_ADDR_START, end_addr: redmule_tile_pkg::L2_ADDR_END};
-  assign obi_xbar_rule[redmule_tile_pkg::L1SPM_IDX] = '{idx: 32'd1, start_addr: TILE_L1_START_ADDR, end_addr: TILE_L1_END_ADDR};
+  assign obi_xbar_rule[redmule_tile_pkg::L2_IDX]    = '{idx: 32'd0, start_addr: redmule_tile_pkg::L2_ADDR_START,    end_addr: redmule_tile_pkg::L2_ADDR_END     };
+  assign obi_xbar_rule[redmule_tile_pkg::L1SPM_IDX] = '{idx: 32'd1, start_addr: TILE_L1_START_ADDR,                 end_addr: TILE_L1_END_ADDR                  };
+  assign obi_xbar_rule[redmule_tile_pkg::STACK_IDX] = '{idx: 32'd1, start_addr: redmule_tile_pkg::STACK_ADDR_START, end_addr: redmule_tile_pkg::STACK_ADDR_END  };
   
   assign obi_xbar_en_default_idx = '1; // Routing to the AXI Xbar all requests with an address outside the range of the internal L1 and the external L2
   assign obi_xbar_default_idx    = '0;

--- a/hw/tile/redmule_tile.sv
+++ b/hw/tile/redmule_tile.sv
@@ -382,6 +382,52 @@ module redmule_tile
     .obi_rsp_o ( idma_obi_write_rsp )
   );
 
+  axi_to_obi #(
+    .ObiCfg       (                                           ),
+    .obi_req_t    ( redmule_tile_pkg::core_obi_data_req_t     ),
+    .obi_rsp_t    ( redmule_tile_pkg::core_obi_data_rsp_t     ),
+    .obi_a_chan_t ( redmule_tile_pkg::core_data_obi_a_chan_t  ),
+    .obi_r_chan_t ( redmule_tile_pkg::core_data_obi_r_chan_t  ),
+    .AxiAddrWidth ( redmule_mesh_pkg::ADDR_W                  ),
+    .AxiDataWidth ( redmule_mesh_pkg::DATA_W                  ),
+    .AxiIdWidth   ( redmule_mesh_pkg::AXI_NOC_ID_W            ),
+    .AxiUserWidth ( redmule_mesh_pkg::AXI_NOC_U_W             ),
+    .MaxTrans     ( 32'd1                                     ),
+    .axi_req_t    ( redmule_mesh_pkg::axi_xbar_mst_req_t      ),
+    .axi_rsp_t    ( redmule_mesh_pkg::axi_xbar_mst_rsp_t      )
+  ) i_axi_to_obi (
+    .clk_i                  ( sys_clk             ),
+    .rst_ni                 ( rst_ni              ),
+    .testmode_i             ( test_mode_i         ),
+    .axi_req_i              ( axi_xbar_mst_req[1] ),
+    .axi_rsp_o              ( axi_xbar_mst_rsp[1] ),
+    .obi_req_o              ( ext_obi_data_req    ),
+    .obi_rsp_i              ( ext_obi_data_rsp    ),
+    .req_aw_id_o            (                     ),
+    .req_aw_user_o          (                     ),
+    .req_w_user_o           (                     ),
+    .req_write_aid_i        ( '0                  ),
+    .req_write_auser_i      ( '0                  ),
+    .req_write_wuser_i      ( '0                  ),
+    .req_ar_id_o            (                     ),
+    .req_ar_user_o          (                     ),
+    .req_read_aid_i         ( '0                  ),
+    .req_read_auser_i       ( '0                  ),
+    .rsp_write_aw_user_o    (                     ),
+    .rsp_write_w_user_o     (                     ),
+    .rsp_write_bank_strb_o  (                     ),
+    .rsp_write_rid_o        (                     ),
+    .rsp_write_ruser_o      (                     ),
+    .rsp_write_last_o       (                     ),
+    .rsp_write_hs_o         (                     ),
+    .rsp_b_user_i           ( '0                  ),
+    .rsp_read_ar_user_o     (                     ),
+    .rsp_read_size_enable_o (                     ),
+    .rsp_read_rid_o         (                     ),
+    .rsp_read_ruser_o       (                     ),
+    .rsp_r_user_i           ( '0                  )
+  );
+
 /*******************************************************/
 /**                Type Conversions End               **/
 /*******************************************************/
@@ -490,26 +536,6 @@ module redmule_tile
 
   `AXI_ASSIGN_REQ_STRUCT(axi_xbar_data_out_req, axi_xbar_mst_req[0])
   `AXI_ASSIGN_RESP_STRUCT(axi_xbar_mst_rsp[0], axi_xbar_data_out_rsp)
-
-  // Temporary AXI error slave until the connection between the Xbar and the internal L1 is ready
-  generate
-    for (genvar i=1; i<redmule_tile_pkg::AxiXbarNoMstPorts; i++) begin
-      axi_err_slv #(
-        .AxiIdWidth ( redmule_mesh_pkg::AXI_NOC_ID_W        ),
-        .axi_req_t  ( redmule_mesh_pkg::axi_xbar_mst_req_t  ),
-        .axi_resp_t ( redmule_mesh_pkg::axi_xbar_mst_rsp_t  )
-      ) i_axi_err_slv (
-        .clk_i  ( sys_clk ),
-        .rst_ni ( rst_ni  ),
-        .test_i ( 1'b0    ),
-        .slv_req_i  ( axi_xbar_mst_req[i] ),
-        .slv_resp_o ( axi_xbar_mst_rsp[i])
-      );
-    end
-  endgenerate
-
-  // Tie ext_obi_data_req until we have the path form the AXI Xbar to the L1
-  assign ext_obi_data_req = '0;
 
 /*******************************************************/
 /**             Interface Assignments End             **/

--- a/hw/tile/redmule_tile.sv
+++ b/hw/tile/redmule_tile.sv
@@ -354,6 +354,52 @@ module redmule_tile
     .obi_rsp_o ( idma_obi_write_rsp )
   );
 
+  axi_to_obi #(
+    .ObiCfg       (                                           ),
+    .obi_req_t    ( redmule_tile_pkg::core_obi_data_req_t     ),
+    .obi_rsp_t    ( redmule_tile_pkg::core_obi_data_rsp_t     ),
+    .obi_a_chan_t ( redmule_tile_pkg::core_data_obi_a_chan_t  ),
+    .obi_r_chan_t ( redmule_tile_pkg::core_data_obi_r_chan_t  ),
+    .AxiAddrWidth ( redmule_mesh_pkg::ADDR_W                  ),
+    .AxiDataWidth ( redmule_mesh_pkg::DATA_W                  ),
+    .AxiIdWidth   ( redmule_mesh_pkg::AXI_NOC_ID_W            ),
+    .AxiUserWidth ( redmule_mesh_pkg::AXI_NOC_U_W             ),
+    .MaxTrans     ( 32'd1                                     ),
+    .axi_req_t    ( redmule_mesh_pkg::axi_xbar_mst_req_t      ),
+    .axi_rsp_t    ( redmule_mesh_pkg::axi_xbar_mst_rsp_t      )
+  ) i_axi_to_obi (
+    .clk_i                  ( sys_clk             ),
+    .rst_ni                 ( rst_ni              ),
+    .testmode_i             ( test_mode_i         ),
+    .axi_req_i              ( axi_xbar_mst_req[1] ),
+    .axi_rsp_o              ( axi_xbar_mst_rsp[1] ),
+    .obi_req_o              ( ext_obi_data_req    ),
+    .obi_rsp_i              ( ext_obi_data_rsp    ),
+    .req_aw_id_o            (                     ),
+    .req_aw_user_o          (                     ),
+    .req_w_user_o           (                     ),
+    .req_write_aid_i        ( '0                  ),
+    .req_write_auser_i      ( '0                  ),
+    .req_write_wuser_i      ( '0                  ),
+    .req_ar_id_o            (                     ),
+    .req_ar_user_o          (                     ),
+    .req_read_aid_i         ( '0                  ),
+    .req_read_auser_i       ( '0                  ),
+    .rsp_write_aw_user_o    (                     ),
+    .rsp_write_w_user_o     (                     ),
+    .rsp_write_bank_strb_o  (                     ),
+    .rsp_write_rid_o        (                     ),
+    .rsp_write_ruser_o      (                     ),
+    .rsp_write_last_o       (                     ),
+    .rsp_write_hs_o         (                     ),
+    .rsp_b_user_i           ( '0                  ),
+    .rsp_read_ar_user_o     (                     ),
+    .rsp_read_size_enable_o (                     ),
+    .rsp_read_rid_o         (                     ),
+    .rsp_read_ruser_o       (                     ),
+    .rsp_r_user_i           ( '0                  )
+  );
+
 /*******************************************************/
 /**                Type Conversions End               **/
 /*******************************************************/
@@ -462,26 +508,6 @@ module redmule_tile
 
   `AXI_ASSIGN_REQ_STRUCT(axi_xbar_data_out_req, axi_xbar_mst_req[0])
   `AXI_ASSIGN_RESP_STRUCT(axi_xbar_mst_rsp[0], axi_xbar_data_out_rsp)
-
-  // Temporary AXI error slave until the connection between the Xbar and the internal L1 is ready
-  generate
-    for (genvar i=1; i<redmule_tile_pkg::AxiXbarNoMstPorts; i++) begin
-      axi_err_slv #(
-        .AxiIdWidth ( redmule_mesh_pkg::AXI_NOC_ID_W        ),
-        .axi_req_t  ( redmule_mesh_pkg::axi_xbar_mst_req_t  ),
-        .axi_resp_t ( redmule_mesh_pkg::axi_xbar_mst_rsp_t  )
-      ) i_axi_err_slv (
-        .clk_i  ( sys_clk ),
-        .rst_ni ( rst_ni  ),
-        .test_i ( 1'b0    ),
-        .slv_req_i  ( axi_xbar_mst_req[i] ),
-        .slv_resp_o ( axi_xbar_mst_rsp[i])
-      );
-    end
-  endgenerate
-
-  // Tie ext_obi_data_req until we have the path form the AXI Xbar to the L1
-  assign ext_obi_data_req = '0;
 
 /*******************************************************/
 /**             Interface Assignments End             **/

--- a/hw/tile/redmule_tile.sv
+++ b/hw/tile/redmule_tile.sv
@@ -65,7 +65,7 @@ module redmule_tile
   output redmule_tile_pkg::axi_xbar_slv_rsp_t     data_in_rsp_o,
 
   // Fractal Sync interface
-  fractal_if.mst_port                             cu_if_o,
+  fractal_if.mst_port                             sync_if_o,
 
   // Signals used by the core
   input  logic                                    scan_cg_en_i,
@@ -973,7 +973,7 @@ module redmule_tile
     .rst_ni         ( rst_ni                                                      ),
     .clear_i        ( fsync_clear                                                 ),
     .xif_issue_if_i ( xif_coproc_if.coproc_issue[redmule_tile_pkg::XIF_FSYNC_IDX] ),
-    .sync_if_o      ( cu_if_o                                                     ),
+    .sync_if_o      ( sync_if_o                                                   ),
     .done_o         ( fsync_done                                                  ),
     .error_o        ( fsync_error                                                 )
   );

--- a/hw/tile/redmule_tile.sv
+++ b/hw/tile/redmule_tile.sv
@@ -65,7 +65,7 @@ module redmule_tile
   output redmule_tile_pkg::axi_xbar_slv_rsp_t     data_in_rsp_o,
 
   // Fractal Sync interface
-  fractal_if.mst_port                             sync_if_o,
+  fractal_if.mst_port                             cu_if_o,
 
   // Signals used by the core
   input  logic                                    scan_cg_en_i,
@@ -973,7 +973,7 @@ module redmule_tile
     .rst_ni         ( rst_ni                                                      ),
     .clear_i        ( fsync_clear                                                 ),
     .xif_issue_if_i ( xif_coproc_if.coproc_issue[redmule_tile_pkg::XIF_FSYNC_IDX] ),
-    .sync_if_o      ( sync_if_o                                                   ),
+    .sync_if_o      ( cu_if_o                                                     ),
     .done_o         ( fsync_done                                                  ),
     .error_o        ( fsync_error                                                 )
   );

--- a/hw/tile/redmule_tile.sv
+++ b/hw/tile/redmule_tile.sv
@@ -19,7 +19,8 @@
  * RedMulE Tile
  */
 
-`include "hci/assign.svh"
+ `include "axi/assign.svh"
+ `include "hci/assign.svh"
 
 module redmule_tile
   import redmule_tile_pkg::*;
@@ -34,6 +35,8 @@ module redmule_tile
   parameter int unsigned          N_MEM_BANKS   = redmule_mesh_pkg::N_MEM_BANKS,  // Number of memory banks 
   parameter int unsigned          N_WORDS_BANK  = redmule_mesh_pkg::N_WORDS_BANK, // Number of words per memory bank      
 
+  parameter int unsigned          TILE_ID       = 0,                              // TODO: fetch the ID from a register within the tile
+
   // Parameters used by the core
   parameter cv32e40x_pkg::rv32_e  CORE_ISA      = cv32e40x_pkg::RV32I,            // RV32I (default) 32 registers in the RF - RV32E 16 registers in the RF
   parameter cv32e40x_pkg::a_ext_e CORE_A        = cv32e40x_pkg::A_NONE,           // Atomic Istruction (A) support (dafault: not enabled)
@@ -41,7 +44,11 @@ module redmule_tile
   parameter cv32e40x_pkg::m_ext_e CORE_M        = cv32e40x_pkg::M,                // Multiply and Divide support (dafault: full support)
 
   // Parameters used by the iDMA
-  parameter idma_pkg::error_cap_e ERROR_CAP     = idma_pkg::NO_ERROR_HANDLING     // Error handaling capability of the iDMA
+  parameter idma_pkg::error_cap_e ERROR_CAP     = idma_pkg::NO_ERROR_HANDLING,     // Error handaling capability of the iDMA
+
+  // Dependent parameters
+  localparam int unsigned         TILE_L1_START_ADDR  = redmule_tile_pkg::L1_ADDR_START + TILE_ID*redmule_tile_pkg::L1_SIZE,
+  localparam int unsigned         TILE_L1_END_ADDR    = TILE_L1_START_ADDR + redmule_tile_pkg::L1_SIZE
 )(
   input  logic                                    clk_i,
   input  logic                                    rst_ni,
@@ -50,6 +57,9 @@ module redmule_tile
 
   output redmule_mesh_pkg::axi_default_req_t      data_out_req_o,
   input  redmule_mesh_pkg::axi_default_rsp_t      data_out_rsp_i,
+
+  input  redmule_tile_pkg::axi_xbar_slv_req_t     data_in_req_i,
+  output redmule_tile_pkg::axi_xbar_slv_rsp_t     data_in_rsp_o,
 
   // Signals used by the core
   input  logic                                    scan_cg_en_i,
@@ -100,6 +110,12 @@ module redmule_tile
   redmule_tile_pkg::core_obi_data_req_t[redmule_tile_pkg::N_SBR-1:0] core_mem_data_req; // Index 0 -> L2, Index 1 -> L1SPM
   redmule_tile_pkg::core_obi_data_rsp_t[redmule_tile_pkg::N_SBR-1:0] core_mem_data_rsp; // Index 0 -> L2, Index 1 -> L1SPM
 
+  redmule_tile_pkg::core_obi_data_req_t[redmule_tile_pkg::N_MGR-1:0] obi_xbar_slv_req; // Index 0 -> core request, Index 1 -> ext request
+  redmule_tile_pkg::core_obi_data_rsp_t[redmule_tile_pkg::N_MGR-1:0] obi_xbar_slv_rsp; // Index 0 -> core request, Index 1 -> ext request
+
+  redmule_tile_pkg::core_obi_data_req_t ext_obi_data_req;
+  redmule_tile_pkg::core_obi_data_rsp_t ext_obi_data_rsp;
+
   redmule_tile_pkg::core_hci_data_req_t core_l1_data_req;
   redmule_tile_pkg::core_hci_data_rsp_t core_l1_data_rsp;
 
@@ -136,8 +152,11 @@ module redmule_tile
   redmule_tile_pkg::idma_hci_req_t idma_hci_write_req;
   redmule_tile_pkg::idma_hci_rsp_t idma_hci_write_rsp;
 
-  redmule_tile_pkg::axi_xbar_slv_req_t[redmule_tile_pkg::AxiXbarNoSlvPorts-1:0] axi_xbar_data_in_req; // Index 2 -> iDMA, Index 1 -> Core Data, Index 0 -> Core Instruction
-  redmule_tile_pkg::axi_xbar_slv_rsp_t[redmule_tile_pkg::AxiXbarNoSlvPorts-1:0] axi_xbar_data_in_rsp; // Index 2 -> iDMA, Index 1 -> Core Data, Index 0 -> Core Instruction
+  redmule_tile_pkg::axi_xbar_slv_req_t[redmule_tile_pkg::AxiXbarNoSlvPorts-1:0] axi_xbar_data_in_req; // Index 3 -> ext, Index 2 -> iDMA, Index 1 -> Core Data, Index 0 -> Core Instruction
+  redmule_tile_pkg::axi_xbar_slv_rsp_t[redmule_tile_pkg::AxiXbarNoSlvPorts-1:0] axi_xbar_data_in_rsp; // Index 3 -> ext, Index 2 -> iDMA, Index 1 -> Core Data, Index 0 -> Core Instruction
+
+  redmule_mesh_pkg::axi_xbar_mst_req_t[redmule_tile_pkg::AxiXbarNoMstPorts-1:0] axi_xbar_mst_req;
+  redmule_mesh_pkg::axi_xbar_mst_rsp_t[redmule_tile_pkg::AxiXbarNoMstPorts-1:0] axi_xbar_mst_rsp;
   
   redmule_mesh_pkg::axi_xbar_mst_req_t axi_xbar_data_out_req;
   redmule_mesh_pkg::axi_xbar_mst_rsp_t axi_xbar_data_out_rsp;
@@ -182,9 +201,9 @@ module redmule_tile
 /*******************************************************/
 
   assign obi_xbar_rule[redmule_tile_pkg::L2_IDX]    = '{idx: 32'd0, start_addr: redmule_tile_pkg::L2_ADDR_START, end_addr: redmule_tile_pkg::L2_ADDR_END};
-  assign obi_xbar_rule[redmule_tile_pkg::L1SPM_IDX] = '{idx: 32'd1, start_addr: redmule_tile_pkg::L1_ADDR_START, end_addr: redmule_tile_pkg::L1_ADDR_END};
+  assign obi_xbar_rule[redmule_tile_pkg::L1SPM_IDX] = '{idx: 32'd1, start_addr: TILE_L1_START_ADDR, end_addr: TILE_L1_END_ADDR};
   
-  assign obi_xbar_en_default_idx = '0;
+  assign obi_xbar_en_default_idx = '1; // Routing to the AXI Xbar all requests with an address outside the range of the internal L1 and the external L2
   assign obi_xbar_default_idx    = '0;
 
   assign data_out_req_o        = axi_xbar_data_out_req;
@@ -196,6 +215,8 @@ module redmule_tile
   assign core_l2_data_rsp                                           = axi_xbar_data_in_rsp[redmule_tile_pkg::AXI_CORE_DATA_IDX];
   assign axi_xbar_data_in_req[redmule_tile_pkg::AXI_CORE_INSTR_IDX] = core_l2_instr_req;
   assign core_l2_instr_rsp                                          = axi_xbar_data_in_rsp[redmule_tile_pkg::AXI_CORE_INSTR_IDX];
+  assign axi_xbar_data_in_req[redmule_tile_pkg::AXI_EXT_IDX]        = data_in_req_i;
+  assign data_in_rsp_o                                              = axi_xbar_data_in_rsp[redmule_tile_pkg::AXI_EXT_IDX];
 
   assign axi_data_user     = '0;
   assign obi_rsp_data_user = '0;
@@ -434,6 +455,34 @@ module redmule_tile
   `HCI_ASSIGN_TO_INTF(hci_dma_if[redmule_tile_pkg::HCI_DMA_CH_READ_IDX],  idma_hci_read_req,  idma_hci_read_rsp)  // iDMA HCI read channel
   `HCI_ASSIGN_TO_INTF(hci_dma_if[redmule_tile_pkg::HCI_DMA_CH_WRITE_IDX], idma_hci_write_req, idma_hci_write_rsp) // iDMA HCI write channel
 
+  assign obi_xbar_slv_req[0] = core_obi_data_req;
+  assign core_obi_data_rsp = obi_xbar_slv_rsp[0];
+  assign obi_xbar_slv_req[1] = ext_obi_data_req;
+  assign ext_obi_data_rsp = obi_xbar_slv_rsp[1];
+
+  `AXI_ASSIGN_REQ_STRUCT(axi_xbar_data_out_req, axi_xbar_mst_req[0])
+  `AXI_ASSIGN_RESP_STRUCT(axi_xbar_mst_rsp[0], axi_xbar_data_out_rsp)
+
+  // Temporary AXI error slave until the connection between the Xbar and the internal L1 is ready
+  generate
+    for (genvar i=1; i<redmule_tile_pkg::AxiXbarNoMstPorts; i++) begin
+      axi_err_slv #(
+        .AxiIdWidth ( redmule_mesh_pkg::AXI_NOC_ID_W        ),
+        .axi_req_t  ( redmule_mesh_pkg::axi_xbar_mst_req_t  ),
+        .axi_resp_t ( redmule_mesh_pkg::axi_xbar_mst_rsp_t  )
+      ) i_axi_err_slv (
+        .clk_i  ( sys_clk ),
+        .rst_ni ( rst_ni  ),
+        .test_i ( 1'b0    ),
+        .slv_req_i  ( axi_xbar_mst_req[i] ),
+        .slv_resp_o ( axi_xbar_mst_rsp[i])
+      );
+    end
+  endgenerate
+
+  // Tie ext_obi_data_req until we have the path form the AXI Xbar to the L1
+  assign ext_obi_data_req = '0;
+
 /*******************************************************/
 /**             Interface Assignments End             **/
 /*******************************************************/
@@ -593,27 +642,30 @@ module redmule_tile
 /**      Core Data Demuxing (OBI XBAR) Beginning      **/
 /*******************************************************/
 
-  obi_demux_addr #(
-    .SbrPortObiCfg      (                                          ),
-    .MgrPortObiCfg      (                                          ),
-    .sbr_port_obi_req_t ( redmule_tile_pkg::core_obi_data_req_t    ),
-    .sbr_port_obi_rsp_t ( redmule_tile_pkg::core_obi_data_rsp_t    ),
-    .mgr_port_obi_req_t (                                          ),
-    .mgr_port_obi_rsp_t (                                          ),
-    .NumMgrPorts        ( redmule_tile_pkg::N_SBR                  ),
-    .NumMaxTrans        ( redmule_tile_pkg::N_MAX_TRAN             ),
-    .NumAddrRules       ( redmule_tile_pkg::N_ADDR_RULE            ),
-    .addr_map_rule_t    ( redmule_tile_pkg::obi_xbar_rule_t        )
+  obi_xbar #(
+    .SbrPortObiCfg      (                                       ),
+    .MgrPortObiCfg      (                                       ),
+    .sbr_port_obi_req_t ( redmule_tile_pkg::core_obi_data_req_t ),
+    .sbr_port_a_chan_t  ( redmule_tile_pkg::core_data_obi_a_chan_t  ),
+    .sbr_port_obi_rsp_t ( redmule_tile_pkg::core_obi_data_rsp_t ),
+    .sbr_port_r_chan_t  ( redmule_tile_pkg::core_data_obi_r_chan_t  ),
+    .mgr_port_obi_req_t (                                       ),
+    .mgr_port_obi_rsp_t (                                       ),
+    .NumSbrPorts        ( redmule_tile_pkg::N_MGR               ),
+    .NumMgrPorts        ( redmule_tile_pkg::N_SBR               ),
+    .NumMaxTrans        ( redmule_tile_pkg::N_MAX_TRAN          ),
+    .NumAddrRules       ( redmule_tile_pkg::N_ADDR_RULE         ),
+    .addr_map_rule_t    ( redmule_tile_pkg::obi_xbar_rule_t     ),
+    .UseIdForRouting    ( 1'b0                                  ),
+    .Connectivity       ( '1                                    )
   ) i_obi_xbar (
     .clk_i            ( sys_clk                 ),
     .rst_ni           ( rst_ni                  ),
-
-    .sbr_ports_req_i  ( core_obi_data_req       ),
-    .sbr_ports_rsp_o  ( core_obi_data_rsp       ),
-
+    .testmode_i       ( test_mode_i             ),
+    .sbr_ports_req_i  ( obi_xbar_slv_req        ),
+    .sbr_ports_rsp_o  ( obi_xbar_slv_rsp        ),
     .mgr_ports_req_o  ( core_mem_data_req       ),
     .mgr_ports_rsp_i  ( core_mem_data_rsp       ),
-
     .addr_map_i       ( obi_xbar_rule           ),
     .en_default_idx_i ( obi_xbar_en_default_idx ),
     .default_idx_i    ( obi_xbar_default_idx    )
@@ -807,37 +859,40 @@ module redmule_tile
 /**         Data Out - L2 (AXI XBAR) Beginning        **/
 /*******************************************************/
 
-  axi_mux #(
-    .SlvAxiIDWidth ( redmule_tile_pkg::AxiXbarSlvAxiIDWidth   ),
-    .slv_aw_chan_t ( redmule_tile_pkg::axi_xbar_slv_aw_chan_t ),
-    .mst_aw_chan_t ( redmule_mesh_pkg::axi_xbar_mst_aw_chan_t ),
-    .w_chan_t      ( redmule_mesh_pkg::axi_xbar_mst_w_chan_t  ),
-    .slv_b_chan_t  ( redmule_tile_pkg::axi_xbar_slv_b_chan_t  ),
-    .mst_b_chan_t  ( redmule_mesh_pkg::axi_xbar_mst_b_chan_t  ),
-    .slv_ar_chan_t ( redmule_tile_pkg::axi_xbar_slv_ar_chan_t ),
-    .mst_ar_chan_t ( redmule_mesh_pkg::axi_xbar_mst_ar_chan_t ),
-    .slv_r_chan_t  ( redmule_tile_pkg::axi_xbar_slv_r_chan_t  ),
-    .mst_r_chan_t  ( redmule_mesh_pkg::axi_xbar_mst_r_chan_t  ),
-    .slv_req_t     ( redmule_tile_pkg::axi_xbar_slv_req_t     ),
-    .slv_resp_t    ( redmule_tile_pkg::axi_xbar_slv_rsp_t     ),
-    .mst_req_t     ( redmule_mesh_pkg::axi_xbar_mst_req_t     ),
-    .mst_resp_t    ( redmule_mesh_pkg::axi_xbar_mst_rsp_t     ),
-    .NoSlvPorts    ( redmule_tile_pkg::AxiXbarNoSlvPorts      ),
-    .MaxWTrans     ( redmule_tile_pkg::AxiXbarMaxWTrans       ),
-    .FallThrough   ( redmule_tile_pkg::AxiXbarFallThrough     ),
-    .SpillAw       ( redmule_tile_pkg::AxiXbarSpillAw         ),
-    .SpillW        ( redmule_tile_pkg::AxiXbarSpillW          ),
-    .SpillB        ( redmule_tile_pkg::AxiXbarSpillB          ),
-    .SpillAr       ( redmule_tile_pkg::AxiXbarSpillAr         ),
-    .SpillR        ( redmule_tile_pkg::AxiXbarSpillR          )
+  localparam axi_pkg::xbar_rule_32_t[redmule_tile_pkg::tile_xbar_cfg.NoAddrRules-1:0] TileAxiAddrMap = '{
+    '{idx: 32'd0, start_addr: redmule_tile_pkg::L2_ADDR_START,  end_addr: redmule_tile_pkg::L2_ADDR_END },
+    '{idx: 32'd1, start_addr: TILE_L1_START_ADDR,               end_addr: TILE_L1_END_ADDR              }
+  };
+
+  axi_xbar #(
+    .Cfg            ( redmule_tile_pkg::tile_xbar_cfg           ),
+    .ATOPs          ( 1'b1                                      ),
+    .Connectivity   ( '1                                        ),
+    .slv_aw_chan_t  ( redmule_tile_pkg::axi_xbar_slv_aw_chan_t  ),
+    .mst_aw_chan_t  ( redmule_mesh_pkg::axi_xbar_mst_aw_chan_t  ),
+    .w_chan_t       ( redmule_mesh_pkg::axi_xbar_mst_w_chan_t   ),
+    .slv_b_chan_t   ( redmule_tile_pkg::axi_xbar_slv_b_chan_t   ),
+    .mst_b_chan_t   ( redmule_mesh_pkg::axi_xbar_mst_b_chan_t   ),
+    .slv_ar_chan_t  ( redmule_tile_pkg::axi_xbar_slv_ar_chan_t  ),
+    .mst_ar_chan_t  ( redmule_mesh_pkg::axi_xbar_mst_ar_chan_t  ),
+    .slv_r_chan_t   ( redmule_tile_pkg::axi_xbar_slv_r_chan_t   ),
+    .mst_r_chan_t   ( redmule_mesh_pkg::axi_xbar_mst_r_chan_t   ),
+    .slv_req_t      ( redmule_tile_pkg::axi_xbar_slv_req_t      ),
+    .mst_req_t      ( redmule_mesh_pkg::axi_xbar_mst_req_t      ),
+    .slv_resp_t     ( redmule_tile_pkg::axi_xbar_slv_rsp_t      ),
+    .mst_resp_t     ( redmule_mesh_pkg::axi_xbar_mst_rsp_t      ),
+    .rule_t         ( redmule_tile_pkg::tile_xbar_rule_t        )
   ) i_axi_xbar (
-    .clk_i       ( sys_clk               ),
-    .rst_ni      ( rst_ni                ),
-    .test_i      ( test_mode_i           ),
-    .slv_reqs_i  ( axi_xbar_data_in_req  ),
-    .slv_resps_o ( axi_xbar_data_in_rsp  ),
-    .mst_req_o   ( axi_xbar_data_out_req ),
-    .mst_resp_i  ( axi_xbar_data_out_rsp )   
+    .clk_i                  ( sys_clk               ),
+    .rst_ni                 ( rst_ni                ),
+    .test_i                 ( test_mode_i           ),
+    .slv_ports_req_i        ( axi_xbar_data_in_req  ),
+    .slv_ports_resp_o       ( axi_xbar_data_in_rsp  ),
+    .mst_ports_req_o        ( axi_xbar_mst_req      ),
+    .mst_ports_resp_i       ( axi_xbar_mst_rsp      ),
+    .addr_map_i             ( TileAxiAddrMap        ),
+    .en_default_mst_port_i  ( '1                    ),
+    .default_mst_port_i     ( '0                    )
   );
 
 /*******************************************************/

--- a/hw/tile/redmule_tile.sv
+++ b/hw/tile/redmule_tile.sv
@@ -210,8 +210,9 @@ module redmule_tile
 /**            Hardwired Signals Beginning            **/
 /*******************************************************/
 
-  assign obi_xbar_rule[redmule_tile_pkg::L2_IDX]    = '{idx: 32'd0, start_addr: redmule_tile_pkg::L2_ADDR_START, end_addr: redmule_tile_pkg::L2_ADDR_END};
-  assign obi_xbar_rule[redmule_tile_pkg::L1SPM_IDX] = '{idx: 32'd1, start_addr: TILE_L1_START_ADDR, end_addr: TILE_L1_END_ADDR};
+  assign obi_xbar_rule[redmule_tile_pkg::L2_IDX]    = '{idx: 32'd0, start_addr: redmule_tile_pkg::L2_ADDR_START,    end_addr: redmule_tile_pkg::L2_ADDR_END     };
+  assign obi_xbar_rule[redmule_tile_pkg::L1SPM_IDX] = '{idx: 32'd1, start_addr: TILE_L1_START_ADDR,                 end_addr: TILE_L1_END_ADDR                  };
+  assign obi_xbar_rule[redmule_tile_pkg::STACK_IDX] = '{idx: 32'd1, start_addr: redmule_tile_pkg::STACK_ADDR_START, end_addr: redmule_tile_pkg::STACK_ADDR_END  };
   
   assign obi_xbar_en_default_idx = '1; // Routing to the AXI Xbar all requests with an address outside the range of the internal L1 and the external L2
   assign obi_xbar_default_idx    = '0;

--- a/hw/tile/redmule_tile.sv
+++ b/hw/tile/redmule_tile.sv
@@ -47,7 +47,7 @@ module redmule_tile
   parameter idma_pkg::error_cap_e ERROR_CAP     = idma_pkg::NO_ERROR_HANDLING,    // Error handaling capability of the iDMA
 
   // Parameter used by the Fractal Sync
-  parameter int unsigned          FSYNC_WIDTH   = redmule_mesh_pkg::TILE_FSYNC_W  // Level width of the Fractal Sync interface
+  parameter int unsigned          FSYNC_WIDTH   = redmule_mesh_pkg::TILE_FSYNC_W, // Level width of the Fractal Sync interface
 
   // Dependent parameters
   localparam int unsigned         TILE_L1_START_ADDR  = redmule_tile_pkg::L1_ADDR_START + TILE_ID*redmule_tile_pkg::L1_SIZE,

--- a/hw/tile/redmule_tile_pkg.sv
+++ b/hw/tile/redmule_tile_pkg.sv
@@ -47,11 +47,14 @@ package redmule_tile_pkg;
   localparam int unsigned IRQ_USED              = 11;
 
   // Address map
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_ADDR_START = 32'h1000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_SIZE       = 32'h1000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_START = L1_ADDR_START + 4*L1_SIZE; // redmule_mesh_tb_pkg::N_TILES*L1_SIZE;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_SIZE       = 32'h1000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_END   = L2_ADDR_START + L2_SIZE;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] STACK_ADDR_START = 32'h0000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] STACK_SIZE       = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] STACK_ADDR_END   = STACK_ADDR_START + STACK_SIZE;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_ADDR_START    = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_SIZE          = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_START    = L1_ADDR_START + 4*L1_SIZE; // redmule_mesh_tb_pkg::N_TILES*L1_SIZE;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_SIZE          = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_END      = L2_ADDR_START + L2_SIZE;
   
   // Parameters used by the HCI
   parameter int unsigned N_HWPE  = 1;                                                   // Number of HWPEs attached to the port
@@ -116,7 +119,7 @@ package redmule_tile_pkg;
   parameter int unsigned N_SBR       = 2;                                               // Number of slaves (HCI, AXI XBAR)
   parameter int unsigned N_MGR       = 2;                                               // Number of masters (Core)
   parameter int unsigned N_MAX_TRAN  = 1;                                               // Number of maximum outstanding transactions
-  parameter int unsigned N_ADDR_RULE = 2;                                               // Number of address rules
+  parameter int unsigned N_ADDR_RULE = 3;                                               // Number of address rules
   localparam int unsigned N_BIT_SBR  = $clog2(N_SBR);                                   // Number of bits required to identify each slave
 
   // Parameters used by AXI
@@ -294,6 +297,7 @@ package redmule_tile_pkg;
   } core_cache_instr_rsp_t;
 
   typedef enum {
+    STACK_IDX = 2,
     L1SPM_IDX = 1,
     L2_IDX    = 0
   } mem_array_idx_e;

--- a/hw/tile/redmule_tile_pkg.sv
+++ b/hw/tile/redmule_tile_pkg.sv
@@ -49,11 +49,14 @@ package redmule_tile_pkg;
   localparam int unsigned IRQ_USED              = 13;
 
   // Address map
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_ADDR_START = 32'h1000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_SIZE       = 32'h1000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_START = L1_ADDR_START + 4*L1_SIZE; // redmule_mesh_tb_pkg::N_TILES*L1_SIZE;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_SIZE       = 32'h1000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_END   = L2_ADDR_START + L2_SIZE;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] STACK_ADDR_START = 32'h0000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] STACK_SIZE       = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] STACK_ADDR_END   = STACK_ADDR_START + STACK_SIZE;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_ADDR_START    = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_SIZE          = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_START    = L1_ADDR_START + 4*L1_SIZE; // redmule_mesh_tb_pkg::N_TILES*L1_SIZE;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_SIZE          = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_END      = L2_ADDR_START + L2_SIZE;
   
   // Parameters used by the HCI
   parameter int unsigned N_HWPE  = 1;                                                   // Number of HWPEs attached to the port
@@ -118,7 +121,7 @@ package redmule_tile_pkg;
   parameter int unsigned N_SBR       = 2;                                               // Number of slaves (HCI, AXI XBAR)
   parameter int unsigned N_MGR       = 2;                                               // Number of masters (Core)
   parameter int unsigned N_MAX_TRAN  = 1;                                               // Number of maximum outstanding transactions
-  parameter int unsigned N_ADDR_RULE = 2;                                               // Number of address rules
+  parameter int unsigned N_ADDR_RULE = 3;                                               // Number of address rules
   localparam int unsigned N_BIT_SBR  = $clog2(N_SBR);                                   // Number of bits required to identify each slave
 
   // Parameters used by AXI
@@ -320,6 +323,7 @@ package redmule_tile_pkg;
   } core_cache_instr_rsp_t;
 
   typedef enum {
+    STACK_IDX = 2,
     L1SPM_IDX = 1,
     L2_IDX    = 0
   } mem_array_idx_e;

--- a/hw/tile/redmule_tile_pkg.sv
+++ b/hw/tile/redmule_tile_pkg.sv
@@ -50,9 +50,10 @@ package redmule_tile_pkg;
 
   // Address map
   localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_ADDR_START = 32'h1000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_ADDR_END   = 32'h2000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_START = 32'h2000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_END   = 32'h3000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_SIZE       = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_START = L1_ADDR_START + 4*L1_SIZE; // redmule_mesh_tb_pkg::N_TILES*L1_SIZE;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_SIZE       = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_END   = L2_ADDR_START + L2_SIZE;
   
   // Parameters used by the HCI
   parameter int unsigned N_HWPE  = 1;                                                   // Number of HWPEs attached to the port
@@ -115,13 +116,13 @@ package redmule_tile_pkg;
   parameter int unsigned RID_WIDTH   = 1;                                               // Width of the rid   signal (response channel identifier, see OBI documentation)
   parameter int unsigned MID_WIDTH   = 1;                                               // Width of the mid   signal (manager identifier, see OBI documentation)
   parameter int unsigned N_SBR       = 2;                                               // Number of slaves (HCI, AXI XBAR)
-  parameter int unsigned N_MGR       = 1;                                               // Number of masters (Core)
+  parameter int unsigned N_MGR       = 2;                                               // Number of masters (Core)
   parameter int unsigned N_MAX_TRAN  = 1;                                               // Number of maximum outstanding transactions
   parameter int unsigned N_ADDR_RULE = 2;                                               // Number of address rules
   localparam int unsigned N_BIT_SBR  = $clog2(N_SBR);                                   // Number of bits required to identify each slave
 
   // Parameters used by AXI
-  parameter int unsigned AXI_DATA_ID_W  = 2;                                            // Width of the AXI Data ID (2 bits: Core, iDMA. I$)
+  parameter int unsigned AXI_DATA_ID_W  = 2;                                            // Width of the AXI Data ID (2 bits: Core, iDMA. I$ ext.)
   parameter int unsigned AXI_INSTR_ID_W = 1;                                            // Width of the AXI Instruction ID (0 bits: direct Core - I$ connection)
   parameter int unsigned AXI_ID_W       = 2;                                            // Width of the AXI Unified Communication Channel ID
   parameter int unsigned AXI_DATA_U_W   = redmule_mesh_pkg::USR_W;                      // Width of the AXI Data User
@@ -239,9 +240,12 @@ package redmule_tile_pkg;
   parameter bit          FSYNC_STALL                = 1;                                // Fractal Sync Stall during synchronization
 
   // Parameters of the AXI XBAR
-  parameter int unsigned AxiXbarNoSlvPorts     = 3;                                     // Number of Slave Ports (iDMA, Core Data and Core I$)
+  parameter int unsigned AxiXbarNoSlvPorts     = 4;                                     // Number of Slave Ports (iDMA, Core Data, Core I$ and ext.)
+  parameter int unsigned AxiXbarNoMstPorts     = 2;                                     // Number of Master Ports (to ext. and to internal L1 from ext.)
   localparam int unsigned AxiXbarSlvAxiIDWidth = AXI_DATA_ID_W;                         // Number of bits to indentify each Slave Port
   parameter int unsigned AxiXbarMaxWTrans      = 16;                                    // Maximum number of outstanding transactions per write
+  parameter int unsigned AxiXbarMaxMstTrans    = 16;
+  parameter int unsigned AxiXbarMaxSlvTrans    = 16;
   parameter bit          AxiXbarFallThrough    = 1'b0;                                  // Enabled -> MUX is purely combinational
   parameter bit          AxiXbarSpillAw        = 1'b0;                                  // Enabled -> Spill register on write master ports, +1 cycle of latency on read channels
   parameter bit          AxiXbarSpillW         = 1'b0;                                  // Enabled -> Spill register on write master ports, +1 cycle of latency on read channels
@@ -321,6 +325,7 @@ package redmule_tile_pkg;
   } mem_array_idx_e;
 
   typedef enum {
+    AXI_EXT_IDX        = 3,
     AXI_IDMA_IDX       = 2,
     AXI_CORE_DATA_IDX  = 1,
     AXI_CORE_INSTR_IDX = 0
@@ -386,8 +391,27 @@ package redmule_tile_pkg;
   } idma_write_meta_channel_t;
 
   `AXI_ALIAS(core_axi_data, axi_xbar_slv, core_axi_data_req_t, axi_xbar_slv_req_t, core_axi_data_rsp_t, axi_xbar_slv_rsp_t)
+  `AXI_ALIAS(core_axi_data, axi_xbar_mst, core_axi_data_req_t, axi_xbar_mst_req_t, core_axi_data_rsp_t, axi_xbar_mst_rsp_t)
 
   `HCI_TYPEDEF_REQ_T(idma_hci_req_t, logic[AWC-1:0], logic[DW_LIC-1:0], logic[SW_LIC-1:0], logic signed[WD_LIC-1:0][AWH:0], logic[UWH-1:0])
   `HCI_TYPEDEF_RSP_T(idma_hci_rsp_t, logic[DW_LIC-1:0], logic[UWH-1:0])
+
+  typedef axi_pkg::xbar_rule_32_t tile_xbar_rule_t;
+  
+  localparam axi_pkg::xbar_cfg_t tile_xbar_cfg = '{
+    NoSlvPorts          : AxiXbarNoSlvPorts,
+    NoMstPorts          : AxiXbarNoMstPorts,
+    MaxMstTrans         : AxiXbarMaxMstTrans,
+    MaxSlvTrans         : AxiXbarMaxSlvTrans,
+    FallThrough         : AxiXbarFallThrough,
+    LatencyMode         : axi_pkg::CUT_ALL_PORTS,
+    PipelineStages      : '0, // TODO: make it parametric
+    AxiIdWidthSlvPorts  : AxiXbarSlvAxiIDWidth,
+    AxiIdUsedSlvPorts   : AxiXbarSlvAxiIDWidth, // check me!
+    UniqueIds           : 1'b0,
+    AxiAddrWidth        : redmule_mesh_pkg::ADDR_W,
+    AxiDataWidth        : redmule_mesh_pkg::DATA_W,
+    NoAddrRules         : 2
+  };
 
 endpackage: redmule_tile_pkg

--- a/hw/tile/redmule_tile_pkg.sv
+++ b/hw/tile/redmule_tile_pkg.sv
@@ -48,9 +48,10 @@ package redmule_tile_pkg;
 
   // Address map
   localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_ADDR_START = 32'h1000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_ADDR_END   = 32'h2000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_START = 32'h2000_0000;
-  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_END   = 32'h3000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L1_SIZE       = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_START = L1_ADDR_START + 4*L1_SIZE; // redmule_mesh_tb_pkg::N_TILES*L1_SIZE;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_SIZE       = 32'h1000_0000;
+  localparam logic[redmule_mesh_pkg::ADDR_W-1:0] L2_ADDR_END   = L2_ADDR_START + L2_SIZE;
   
   // Parameters used by the HCI
   parameter int unsigned N_HWPE  = 1;                                                   // Number of HWPEs attached to the port
@@ -113,13 +114,13 @@ package redmule_tile_pkg;
   parameter int unsigned RID_WIDTH   = 1;                                               // Width of the rid   signal (response channel identifier, see OBI documentation)
   parameter int unsigned MID_WIDTH   = 1;                                               // Width of the mid   signal (manager identifier, see OBI documentation)
   parameter int unsigned N_SBR       = 2;                                               // Number of slaves (HCI, AXI XBAR)
-  parameter int unsigned N_MGR       = 1;                                               // Number of masters (Core)
+  parameter int unsigned N_MGR       = 2;                                               // Number of masters (Core)
   parameter int unsigned N_MAX_TRAN  = 1;                                               // Number of maximum outstanding transactions
   parameter int unsigned N_ADDR_RULE = 2;                                               // Number of address rules
   localparam int unsigned N_BIT_SBR  = $clog2(N_SBR);                                   // Number of bits required to identify each slave
 
   // Parameters used by AXI
-  parameter int unsigned AXI_DATA_ID_W  = 2;                                            // Width of the AXI Data ID (2 bits: Core, iDMA. I$)
+  parameter int unsigned AXI_DATA_ID_W  = 2;                                            // Width of the AXI Data ID (2 bits: Core, iDMA. I$ ext.)
   parameter int unsigned AXI_INSTR_ID_W = 1;                                            // Width of the AXI Instruction ID (0 bits: direct Core - I$ connection)
   parameter int unsigned AXI_ID_W       = 2;                                            // Width of the AXI Unified Communication Channel ID
   parameter int unsigned AXI_DATA_U_W   = redmule_mesh_pkg::USR_W;                      // Width of the AXI Data User
@@ -202,9 +203,12 @@ package redmule_tile_pkg;
   parameter logic[ DMA_FUNC3_W-1:0] SET_S_FUNC3   = 3'b111;                             // iDMA Decoder START instruction FUNC3
 
   // Parameters of the AXI XBAR
-  parameter int unsigned AxiXbarNoSlvPorts     = 3;                                     // Number of Slave Ports (iDMA, Core Data and Core I$)
+  parameter int unsigned AxiXbarNoSlvPorts     = 4;                                     // Number of Slave Ports (iDMA, Core Data, Core I$ and ext.)
+  parameter int unsigned AxiXbarNoMstPorts     = 2;                                     // Number of Master Ports (to ext. and to internal L1 from ext.)
   localparam int unsigned AxiXbarSlvAxiIDWidth = AXI_DATA_ID_W;                         // Number of bits to indentify each Slave Port
   parameter int unsigned AxiXbarMaxWTrans      = 16;                                    // Maximum number of outstanding transactions per write
+  parameter int unsigned AxiXbarMaxMstTrans    = 16;
+  parameter int unsigned AxiXbarMaxSlvTrans    = 16;
   parameter bit          AxiXbarFallThrough    = 1'b0;                                  // Enabled -> MUX is purely combinational
   parameter bit          AxiXbarSpillAw        = 1'b0;                                  // Enabled -> Spill register on write master ports, +1 cycle of latency on read channels
   parameter bit          AxiXbarSpillW         = 1'b0;                                  // Enabled -> Spill register on write master ports, +1 cycle of latency on read channels
@@ -295,6 +299,7 @@ package redmule_tile_pkg;
   } mem_array_idx_e;
 
   typedef enum {
+    AXI_EXT_IDX        = 3,
     AXI_IDMA_IDX       = 2,
     AXI_CORE_DATA_IDX  = 1,
     AXI_CORE_INSTR_IDX = 0
@@ -360,8 +365,27 @@ package redmule_tile_pkg;
   } idma_write_meta_channel_t;
 
   `AXI_ALIAS(core_axi_data, axi_xbar_slv, core_axi_data_req_t, axi_xbar_slv_req_t, core_axi_data_rsp_t, axi_xbar_slv_rsp_t)
+  `AXI_ALIAS(core_axi_data, axi_xbar_mst, core_axi_data_req_t, axi_xbar_mst_req_t, core_axi_data_rsp_t, axi_xbar_mst_rsp_t)
 
   `HCI_TYPEDEF_REQ_T(idma_hci_req_t, logic[AWC-1:0], logic[DW_LIC-1:0], logic[SW_LIC-1:0], logic signed[WD_LIC-1:0][AWH:0], logic[UWH-1:0])
   `HCI_TYPEDEF_RSP_T(idma_hci_rsp_t, logic[DW_LIC-1:0], logic[UWH-1:0])
+
+  typedef axi_pkg::xbar_rule_32_t tile_xbar_rule_t;
+  
+  localparam axi_pkg::xbar_cfg_t tile_xbar_cfg = '{
+    NoSlvPorts          : AxiXbarNoSlvPorts,
+    NoMstPorts          : AxiXbarNoMstPorts,
+    MaxMstTrans         : AxiXbarMaxMstTrans,
+    MaxSlvTrans         : AxiXbarMaxSlvTrans,
+    FallThrough         : AxiXbarFallThrough,
+    LatencyMode         : axi_pkg::CUT_ALL_PORTS,
+    PipelineStages      : '0, // TODO: make it parametric
+    AxiIdWidthSlvPorts  : AxiXbarSlvAxiIDWidth,
+    AxiIdUsedSlvPorts   : AxiXbarSlvAxiIDWidth, // check me!
+    UniqueIds           : 1'b0,
+    AxiAddrWidth        : redmule_mesh_pkg::ADDR_W,
+    AxiDataWidth        : redmule_mesh_pkg::DATA_W,
+    NoAddrRules         : 2
+  };
 
 endpackage: redmule_tile_pkg

--- a/scripts/s19tomem.py
+++ b/scripts/s19tomem.py
@@ -23,7 +23,7 @@ import sys
 # Stack starts at 0x2c04_0000
 # We only keep last 2 bytes so memory will be filled with no offset.
 # The CPU will also reference it as to not have any offset.
-MEM_START  = 0x2c000000
+MEM_START  = 0x5c000000
 INSTR_SIZE = 0x8000
 INSTR_END  = MEM_START + INSTR_SIZE
 DATA_BASE  = MEM_START + 0x10000

--- a/sw/kernel/link.ld
+++ b/sw/kernel/link.ld
@@ -22,7 +22,7 @@ MEMORY
 {
     instrram    : ORIGIN = 0x5c000000, LENGTH = 0x8000
     dataram     : ORIGIN = 0x5c010000, LENGTH = 0x30000
-    stack       : ORIGIN = 0x5c040000, LENGTH = 0x30000
+    stack       : ORIGIN = 0x0c08E000, LENGTH = 0x2000 /* 8K, maybe it's a bit too much (?) */
 }
 
 /* Stack information variables */

--- a/sw/kernel/link.ld
+++ b/sw/kernel/link.ld
@@ -20,9 +20,9 @@ __DYNAMIC  =  0;
 
 MEMORY
 {
-    instrram    : ORIGIN = 0x2c000000, LENGTH = 0x8000
-    dataram     : ORIGIN = 0x2c010000, LENGTH = 0x30000
-    stack       : ORIGIN = 0x2c040000, LENGTH = 0x30000
+    instrram    : ORIGIN = 0x5c000000, LENGTH = 0x8000
+    dataram     : ORIGIN = 0x5c010000, LENGTH = 0x30000
+    stack       : ORIGIN = 0x5c040000, LENGTH = 0x30000
 }
 
 /* Stack information variables */

--- a/sw/tests/boot_test.c
+++ b/sw/tests/boot_test.c
@@ -1,7 +1,7 @@
 #include "redmule_tile_utils.h"
 
 int main(void) {
-  mmio32(TEST_END_ADDR) = DEFAULT_EXIT_CODE;
+  mmio8(TEST_END_ADDR) = DEFAULT_EXIT_CODE;
 
   return 0;
 }

--- a/sw/tests/fsync_test.c
+++ b/sw/tests/fsync_test.c
@@ -2,9 +2,9 @@
 #include "redmule_mesh_utils.h"
 #include "fsync_isa_utils.h"
 
-#define NUM_HARTS (2)
+#define NUM_HARTS (4)
 
-#define NUM_LEVELS (1)
+#define NUM_LEVELS (2)
 
 #define STALLING
 
@@ -37,7 +37,7 @@ int main(void) {
 
   h_pprintf("Fractal Sync test finished...\n");
 
-  mmio32(TEST_END_ADDR + get_hartid()) = DEFAULT_EXIT_CODE - get_hartid();
+  mmio8(TEST_END_ADDR + get_hartid()) = DEFAULT_EXIT_CODE - get_hartid();
 
   return 0;
 }

--- a/sw/tests/hello_mesh.c
+++ b/sw/tests/hello_mesh.c
@@ -4,7 +4,7 @@
 int main(void) {
   h_pprintf("Hello World! it is hartid "); pprintf(ds(get_hartid())); pprintln;
 
-  mmio32(TEST_END_ADDR + get_hartid()) = DEFAULT_EXIT_CODE - get_hartid();
+  mmio8(TEST_END_ADDR + get_hartid()) = DEFAULT_EXIT_CODE - get_hartid();
 
   return 0;
 }

--- a/sw/tests/hello_world.c
+++ b/sw/tests/hello_world.c
@@ -5,7 +5,7 @@
 int main(void) {
   printf("Hello World! it is test %0x\n", TEST_ID*16);
 
-  mmio32(TEST_END_ADDR) = DEFAULT_EXIT_CODE;
+  mmio8(TEST_END_ADDR) = DEFAULT_EXIT_CODE;
 
   return 0;
 }

--- a/sw/tests/idma_test.c
+++ b/sw/tests/idma_test.c
@@ -228,7 +228,7 @@ int main(void) {
   else
     exit_code = PASS_EXIT_CODE;
 
-  mmio32(TEST_END_ADDR) = exit_code;
+  mmio8(TEST_END_ADDR) = exit_code;
 
   return 0;
 }

--- a/sw/tests/inter_l1_test.c
+++ b/sw/tests/inter_l1_test.c
@@ -1,0 +1,37 @@
+#include "redmule_mesh_utils.h"
+
+int main() {
+    int32_t error = 0;
+
+    // Write the tiles ID to different L1 memory locations in other tiles
+    for(int i=0; i<4; i++) {
+        if(get_hartid() != i) {
+            *(volatile int*) (L1_BASE + i*L1_SIZE + 0x1000 + get_hartid()*4) = (int) get_hartid();
+        }
+    }
+
+    // Read back the values
+    for (int i=0; i<4; i++) {
+        if(get_hartid() != i) {
+            if (*(volatile int *) (L1_BASE + i*L1_SIZE + 0x1000 + get_hartid()*4) != get_hartid()) {
+                h_pprintf("Read wrong value, expected "); pprintf(ds(get_hartid())); pprintln;
+                error++;
+            }
+        }
+    }
+
+    
+    if(error == 0) {
+        if(get_hartid() == 0) {
+            h_pprintf("TEST PASSED!!"); pprintln;
+        }
+        mmio8(TEST_END_ADDR + get_hartid()) = PASS_EXIT_CODE;
+    } else {
+        if (get_hartid() == 0) {
+            h_pprintf("TEST FAILED!!"); pprintln;
+        }
+        mmio8(TEST_END_ADDR + get_hartid()) = FAIL_EXIT_CODE;
+    }
+
+    return 0;
+}

--- a/sw/tests/l1_test.c
+++ b/sw/tests/l1_test.c
@@ -10,13 +10,13 @@
 
 // Defining the actual number of words per bank
 // to be checked in order to avoid overwriting the stack
-#define ACTIVE_WORDS (((STACK_START+0x10000000-L1_BASE)/4 - 31)/32)
+#define ACTIVE_WORDS (((STACK_START+L1_SIZE-L1_BASE+1)/4)/32)
 
 int main(void) {
   uint8_t exit_code;
 
 #ifdef FULL_L1
-  uint32_t expected_result = (uint32_t)((NUM_L1_BANKS*ACTIVE_WORDS/STEP)*(NUM_L1_BANKS*ACTIVE_WORDS/STEP + 1)/2);
+  uint32_t expected_result = (NUM_L1_BANKS*ACTIVE_WORDS/STEP)*(NUM_L1_BANKS*ACTIVE_WORDS/STEP + 1)/2;
 #endif
 #ifndef FULL_L1
 #ifdef DIAGONAL_L1

--- a/sw/tests/l1_test.c
+++ b/sw/tests/l1_test.c
@@ -8,15 +8,19 @@
 
 #define ALIVE_CYCLE (4096)
 
+// Defining the actual number of words per bank
+// to be checked in order to avoid overwriting the stack
+#define ACTIVE_WORDS (((STACK_START+0x10000000-L1_BASE)/4 - 31)/32)
+
 int main(void) {
   uint8_t exit_code;
 
 #ifdef FULL_L1
-  uint32_t expected_result = (NUM_L1_BANKS*WORDS_BANK/STEP)*(NUM_L1_BANKS*WORDS_BANK/STEP + 1)/2;
+  uint32_t expected_result = (uint32_t)((NUM_L1_BANKS*ACTIVE_WORDS/STEP)*(NUM_L1_BANKS*ACTIVE_WORDS/STEP + 1)/2);
 #endif
 #ifndef FULL_L1
 #ifdef DIAGONAL_L1
-  uint32_t expected_result = (WORDS_BANK)*(WORDS_BANK + 1)/2;
+  uint32_t expected_result = (ACTIVE_WORDS)*(ACTIVE_WORDS + 1)/2;
 #endif
 #endif
 #ifndef FULL_L1
@@ -36,8 +40,8 @@ int main(void) {
 #ifdef FULL_L1
   printf("Checking entire L1 read and write...\n");
 
-  int expected_stored_num = 1;
-  for (int i = 1; i < NUM_L1_BANKS*WORDS_BANK; i += STEP){
+  uint32_t expected_stored_num = 1;
+  for (uint32_t i = 1; i < NUM_L1_BANKS*ACTIVE_WORDS; i += STEP){
     uint32_t read_mem = mmio32(L1_BASE + 0x4*i);
     if (read_mem != 0)
       printf("!MEMORY OVERWRITE! iteration %d - address 0x%8x - value %0d...\n", i, L1_BASE + 0x4*i, read_mem);
@@ -49,8 +53,8 @@ int main(void) {
   }
     
   printf("expected_stored_num: %d...\n", expected_stored_num);
-  int expected_sum = expected_stored_num;
-  for (int i = NUM_L1_BANKS*WORDS_BANK-1; i > 0; i -= STEP){
+  uint32_t expected_sum = expected_stored_num;
+  for (uint32_t i = NUM_L1_BANKS*ACTIVE_WORDS-1; i > 0; i -= STEP){
     mmio32(L1_BASE + 0x4*(i-1)) += mmio32(L1_BASE + 0x4*i);
     if (!(i%ALIVE_CYCLE)) printf("Transactions happening phase II...\n");
     expected_sum += i;
@@ -63,7 +67,7 @@ int main(void) {
   printf("Checking diagonal L1 read and write...\n");
 
   int expected_stored_num = 1;
-  for (int i = 1; i < WORDS_BANK; i++){
+  for (int i = 1; i < ACTIVE_WORDS; i++){
     mmio32(L1_BASE + 0x4*(i%NUM_L1_BANKS + i*NUM_L1_BANKS)) = mmio32(L1_BASE + 0x4*((i-1)%NUM_L1_BANKS + (i-1)*NUM_L1_BANKS)) + 1;
     expected_stored_num++;
     if (expected_stored_num != mmio32(L1_BASE + 0x4*(i%NUM_L1_BANKS + i*NUM_L1_BANKS)))
@@ -72,7 +76,7 @@ int main(void) {
 
   printf("expected_stored_num: %d...\n", expected_stored_num);
   int expected_sum = expected_stored_num;
-  for (int i = WORDS_BANK-1; i > 0; i--){
+  for (int i = ACTIVE_WORDS-1; i > 0; i--){
     mmio32(L1_BASE + 0x4*((i-1)%NUM_L1_BANKS + (i-1)*NUM_L1_BANKS)) += mmio32(L1_BASE + 0x4*(i%NUM_L1_BANKS + i*NUM_L1_BANKS));
     expected_sum += i;
     if (expected_sum != mmio32(L1_BASE + 0x4*((i-1)%NUM_L1_BANKS + (i-1)*NUM_L1_BANKS)))
@@ -99,7 +103,7 @@ int main(void) {
     printf("FAIL: expected %0d, detected %0d...\n", expected_result, mmio32(L2_BASE));
   }
 
-  mmio32(TEST_END_ADDR) = exit_code;
+  mmio8(TEST_END_ADDR) = exit_code;
 
   return 0;
 }

--- a/sw/tests/mesh_test.c
+++ b/sw/tests/mesh_test.c
@@ -17,6 +17,8 @@
 
 #define MHARTID_OFFSET (0x00010000)
 
+#define TILE_OFFSET (0x10000000)
+
 #define NUM_HARTS (4)
 
 #define M_SIZE (96)
@@ -213,15 +215,15 @@ void idma_mv_out(unsigned int x_dim, unsigned int y_dim, uint32_t src_address, u
 int main(void) {
   // X
   h_pprintf("Initializing X through iDMA...\n");
-  idma_mv_in(M_SIZE, N_SIZE, x_inp, (X_BASE + get_hartid()*0x10000000));
+  idma_mv_in(M_SIZE, N_SIZE, x_inp, (X_BASE + get_hartid()*TILE_OFFSET));
 
   // W
   h_pprintf("Initializing W through iDMA...\n");
-  idma_mv_in(N_SIZE, K_SIZE, w_inp, (W_BASE + get_hartid()*0x10000000));
+  idma_mv_in(N_SIZE, K_SIZE, w_inp, (W_BASE + get_hartid()*TILE_OFFSET));
 
   // Y
   h_pprintf("Initializing Y through iDMA...\n");
-  idma_mv_in(M_SIZE, K_SIZE, y_inp, (Y_BASE + get_hartid()*0x10000000));
+  idma_mv_in(M_SIZE, K_SIZE, y_inp, (Y_BASE + get_hartid()*TILE_OFFSET));
 
   uint32_t cfg_reg0[NUM_HARTS];
   uint32_t cfg_reg1[NUM_HARTS];
@@ -237,9 +239,9 @@ int main(void) {
   h_pprintf("cfg_reg1: 0x"); n_pprintf(hs(cfg_reg1[get_hartid()]));
 #endif
 
-  asm volatile("addi t0, %0, 0" ::"r"((uint32_t)(X_BASE + get_hartid()*0x10000000)));
-  asm volatile("addi t1, %0, 0" ::"r"((uint32_t)(W_BASE + get_hartid()*0x10000000)));
-  asm volatile("addi t2, %0, 0" ::"r"((uint32_t)(Y_BASE + get_hartid()*0x10000000)));
+  asm volatile("addi t0, %0, 0" ::"r"((uint32_t)(X_BASE + get_hartid()*TILE_OFFSET)));
+  asm volatile("addi t1, %0, 0" ::"r"((uint32_t)(W_BASE + get_hartid()*TILE_OFFSET)));
+  asm volatile("addi t2, %0, 0" ::"r"((uint32_t)(Y_BASE + get_hartid()*TILE_OFFSET)));
   asm volatile("addi t3, %0, 0" ::"r"(cfg_reg0[get_hartid()]));
   asm volatile("addi t4, %0, 0" ::"r"(cfg_reg1[get_hartid()]));
 
@@ -262,7 +264,7 @@ int main(void) {
 #endif
 
   h_pprintf("Moving results through iDMA...\n");
-  idma_mv_out(M_SIZE, K_SIZE, Y_BASE + get_hartid() * 0x10000000, V_BASE + get_hartid() * MHARTID_OFFSET);
+  idma_mv_out(M_SIZE, K_SIZE, Y_BASE + get_hartid()*TILE_OFFSET, V_BASE + get_hartid()*MHARTID_OFFSET);
 
   h_pprintf("Verifying results...\n");
   

--- a/sw/tests/redmule_test.c
+++ b/sw/tests/redmule_test.c
@@ -113,7 +113,7 @@ int main(void) {
   else
     exit_code = PASS_EXIT_CODE;
 
-  mmio32(TEST_END_ADDR) = exit_code;
+  mmio8(TEST_END_ADDR) = exit_code;
 
   return 0;
 }

--- a/sw/tests/tile_test.c
+++ b/sw/tests/tile_test.c
@@ -283,7 +283,7 @@ int main(void) {
   else
     exit_code = PASS_EXIT_CODE;
 
-  mmio32(TEST_END_ADDR) = exit_code;
+  mmio8(TEST_END_ADDR) = exit_code;
 
   return 0;
 }

--- a/sw/utils/redmule_mesh_utils.h
+++ b/sw/utils/redmule_mesh_utils.h
@@ -10,9 +10,6 @@
 #define n_pprintf(x) (n_psprint(get_hartid(), x))
 #define   pprintf(x) (  psprint(get_hartid(), x))
 #define   pprintln   (  pprintf("\n"))
-#define bs(x) (itoa(x, STR_BASE, 2))
-#define ds(x) (itoa(x, STR_BASE, 10))
-#define hs(x) (itoa(x, STR_BASE, 16))
 
 inline uint32_t get_hartid(){
     uint32_t hartid;
@@ -52,39 +49,60 @@ char* itoa(int value, char* result, int base) {
     return result;
 }
 
+char* bs(uint32_t x) {
+    uint32_t hartid = get_hartid();
+    char *address = STR_BASE + L1_SIZE*hartid;
+
+    return itoa(x, address, 2);
+}
+
+char* ds(uint32_t x) {
+    uint32_t hartid = get_hartid();
+    char *address = STR_BASE + L1_SIZE*hartid;
+
+    return itoa(x, address, 10);
+}
+
+char* hs(uint32_t x) {
+    uint32_t hartid = get_hartid();
+    char *address = STR_BASE + L1_SIZE*hartid;
+
+    return itoa(x, address, 16);
+}
+
 void h_psprint(uint32_t hartid, const char* string){
-    mmio8(0x2FFF0004 + (hartid*4)) = '[';
-    mmio8(0x2FFF0004 + (hartid*4)) = 'm';
-    mmio8(0x2FFF0004 + (hartid*4)) = 'h';
-    mmio8(0x2FFF0004 + (hartid*4)) = 'a';
-    mmio8(0x2FFF0004 + (hartid*4)) = 'r';
-    mmio8(0x2FFF0004 + (hartid*4)) = 't';
-    mmio8(0x2FFF0004 + (hartid*4)) = 'i';
-    mmio8(0x2FFF0004 + (hartid*4)) = 'd';
-    mmio8(0x2FFF0004 + (hartid*4)) = ' ';
+    mmio8(0x5FFF0004 + (hartid*4)) = '[';
+    mmio8(0x5FFF0004 + (hartid*4)) = 'm';
+    mmio8(0x5FFF0004 + (hartid*4)) = 'h';
+    mmio8(0x5FFF0004 + (hartid*4)) = 'a';
+    mmio8(0x5FFF0004 + (hartid*4)) = 'r';
+    mmio8(0x5FFF0004 + (hartid*4)) = 't';
+    mmio8(0x5FFF0004 + (hartid*4)) = 'i';
+    mmio8(0x5FFF0004 + (hartid*4)) = 'd';
+    mmio8(0x5FFF0004 + (hartid*4)) = ' ';
     char*   mhardid_str = ds(hartid);
     uint8_t mhartid_idx = 0;
     while (mhardid_str[mhartid_idx] != '\0')
-        mmio8(0x2FFF0004 + (hartid*4)) = mhardid_str[mhartid_idx++];
-    mmio8(0x2FFF0004 + (hartid*4)) = ']';
-    mmio8(0x2FFF0004 + (hartid*4)) = ' ';
+        mmio8(0x5FFF0004 + (hartid*4)) = mhardid_str[mhartid_idx++];
+    mmio8(0x5FFF0004 + (hartid*4)) = ']';
+    mmio8(0x5FFF0004 + (hartid*4)) = ' ';
 
     uint8_t index = 0;
     while (string[index] != '\0')
-        mmio8(0x2FFF0004 + (hartid*4)) = string[index++];
+        mmio8(0x5FFF0004 + (hartid*4)) = string[index++];
 }
 
 void n_psprint(uint32_t hartid, const char* string){
     uint8_t index = 0;
     while (string[index] != '\0')
-        mmio8(0x2FFF0004 + (hartid*4)) = string[index++];
-    mmio8(0x2FFF0004 + (hartid*4)) = '\n';
+        mmio8(0x5FFF0004 + (hartid*4)) = string[index++];
+    mmio8(0x5FFF0004 + (hartid*4)) = '\n';
 }
 
 void psprint(uint32_t hartid, const char* string){
     uint8_t index = 0;
     while (string[index] != '\0')
-        mmio8(0x2FFF0004 + (hartid*4)) = string[index++];
+        mmio8(0x5FFF0004 + (hartid*4)) = string[index++];
 }
 
 #endif /*REDMULE_MESH_UTILS_H*/

--- a/sw/utils/redmule_tile_utils.h
+++ b/sw/utils/redmule_tile_utils.h
@@ -8,8 +8,9 @@
 #define BITS_WORD    (32)
 
 #define L1_BASE       (0x1C010000)
-#define L2_BASE       (0x2C010000)
-#define TEST_END_ADDR (0x2C030000)
+#define L1_SIZE       (0x10000000)
+#define L2_BASE       (0x5C010000)
+#define TEST_END_ADDR (0x5C030000)
 
 #define DEFAULT_EXIT_CODE (0xAF)
 #define PASS_EXIT_CODE    (0xA)

--- a/sw/utils/redmule_tile_utils.h
+++ b/sw/utils/redmule_tile_utils.h
@@ -7,6 +7,8 @@
 #define WORDS_BANK   (4096)
 #define BITS_WORD    (32)
 
+#define STACK_START   (0x0C08E000)
+#define STACK_END     (0x0C090000)
 #define L1_BASE       (0x1C010000)
 #define L1_SIZE       (0x10000000)
 #define L2_BASE       (0x5C010000)

--- a/sw/utils/tinyprintf.h
+++ b/sw/utils/tinyprintf.h
@@ -108,7 +108,7 @@ regs Kusti, 23.10.2004
 */
 
 void putf(char *null, char c) {
-  *(volatile int *) (0x2FFF0004) = (int)c;
+  *(volatile int *) (0x5FFF0004) = (int)c;
 }
 
 #ifndef __TFP_PRINTF__

--- a/target/src/mesh/redmule_mesh_fixture.sv
+++ b/target/src/mesh/redmule_mesh_fixture.sv
@@ -30,49 +30,49 @@ module redmule_mesh_fixture;
 /**        Internal Signal Definitions Beginning      **/
 /*******************************************************/
 
-  logic                                                                 clk;
-  logic                                                                 rst_n;
-  logic                                                                 test_mode;
-  logic                                                                 tile_enable;
+  logic                                                                   clk;
+  logic                                                                   rst_n;
+  logic                                                                   test_mode;
+  logic                                                                   tile_enable;
 
-  redmule_mesh_pkg::axi_default_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_req;
-  redmule_mesh_pkg::axi_default_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_rsp;
+  redmule_mesh_pkg::axi_default_req_t[redmule_mesh_tb_pkg::N_TILES-1:0]   data_out_req;
+  redmule_mesh_pkg::axi_default_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0]   data_out_rsp;
 
   redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_req;
   redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_rsp;
 
-  redmule_tile_pkg::axi_xbar_slv_req_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_req;
-  redmule_tile_pkg::axi_xbar_slv_rsp_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_rsp;
+  redmule_tile_pkg::axi_xbar_slv_req_t[redmule_mesh_tb_pkg::N_TILES:0]    tile_data_mst_req;
+  redmule_tile_pkg::axi_xbar_slv_rsp_t[redmule_mesh_tb_pkg::N_TILES:0]    tile_data_mst_rsp;
 
-  fractal_if #(.LVL_WIDTH($clog2(redmule_mesh_tb_pkg::N_TILES)+1))      sync_if[redmule_mesh_tb_pkg::N_TILES]();
+  fractal_if #(.LVL_WIDTH($clog2(redmule_mesh_tb_pkg::N_TILES)+1))        sync_if[redmule_mesh_tb_pkg::N_TILES]();
   
-  logic                                                                 scan_cg_en;
+  logic                                                                   scan_cg_en;
 
-  logic[31:0]                                                           boot_addr;
-  logic[31:0]                                                           mtvec_addr;
-  logic[31:0]                                                           dm_halt_addr;
-  logic[31:0]                                                           dm_exception_addr;
-  logic[31:0]                                                           mhartid[redmule_mesh_tb_pkg::N_TILES];
-  logic[ 3:0]                                                           mimpid_patch;
+  logic[31:0]                                                             boot_addr;
+  logic[31:0]                                                             mtvec_addr;
+  logic[31:0]                                                             dm_halt_addr;
+  logic[31:0]                                                             dm_exception_addr;
+  logic[31:0]                                                             mhartid[redmule_mesh_tb_pkg::N_TILES];
+  logic[ 3:0]                                                             mimpid_patch;
 
-  logic[63:0]                                                           mcycle[redmule_mesh_tb_pkg::N_TILES];
-  logic[63:0]                                                           time_var;
+  logic[63:0]                                                             mcycle[redmule_mesh_tb_pkg::N_TILES];
+  logic[63:0]                                                             time_var;
 
-  logic[redmule_mesh_pkg::N_IRQ-1:0]                                    irq;
+  logic[redmule_mesh_pkg::N_IRQ-1:0]                                      irq;
 
-  logic                                                                 fencei_flush_req[redmule_mesh_tb_pkg::N_TILES];
-  logic                                                                 fencei_flush_ack;
+  logic                                                                   fencei_flush_req[redmule_mesh_tb_pkg::N_TILES];
+  logic                                                                   fencei_flush_ack;
 
-  logic                                                                 debug_req;
-  logic                                                                 debug_havereset[redmule_mesh_tb_pkg::N_TILES];
-  logic                                                                 debug_running[redmule_mesh_tb_pkg::N_TILES];
-  logic                                                                 debug_halted[redmule_mesh_tb_pkg::N_TILES];
-  logic                                                                 debug_pc_valid[redmule_mesh_tb_pkg::N_TILES];
-  logic[31:0]                                                           debug_pc[redmule_mesh_tb_pkg::N_TILES];
+  logic                                                                   debug_req;
+  logic                                                                   debug_havereset[redmule_mesh_tb_pkg::N_TILES];
+  logic                                                                   debug_running[redmule_mesh_tb_pkg::N_TILES];
+  logic                                                                   debug_halted[redmule_mesh_tb_pkg::N_TILES];
+  logic                                                                   debug_pc_valid[redmule_mesh_tb_pkg::N_TILES];
+  logic[31:0]                                                             debug_pc[redmule_mesh_tb_pkg::N_TILES];
 
-  logic                                                                 fetch_enable;
-  logic                                                                 core_sleep[redmule_mesh_tb_pkg::N_TILES];
-  logic                                                                 wu_wfe;
+  logic                                                                   fetch_enable;
+  logic                                                                   core_sleep[redmule_mesh_tb_pkg::N_TILES];
+  logic                                                                   wu_wfe;
 
 /*******************************************************/
 /**           Internal Signal Definitions End         **/
@@ -105,6 +105,7 @@ module redmule_mesh_fixture;
       .mst_resp_i ( tile_data_mst_rsp[i]  )
     );
   end
+  
 /*******************************************************/
 /**                   DUT Beginning                   **/
 /*******************************************************/
@@ -120,46 +121,46 @@ module redmule_mesh_fixture;
       .CORE_B       (                                   ),
       .CORE_M       (                                   )
     ) dut (
-      .clk_i               ( clk                 ),
-      .rst_ni              ( rst_n               ),
-      .test_mode_i         ( test_mode           ),
-      .tile_enable_i       ( tile_enable         ),
+      .clk_i               ( clk                  ),
+      .rst_ni              ( rst_n                ),
+      .test_mode_i         ( test_mode            ),
+      .tile_enable_i       ( tile_enable          ),
 
-      .data_out_req_o      ( data_out_req[i]     ),
-      .data_out_rsp_i      ( data_out_rsp[i]     ),
+      .data_out_req_o      ( data_out_req[i]      ),
+      .data_out_rsp_i      ( data_out_rsp[i]      ),
 
-      .data_in_req_i       ( tile_data_mst_req[i]     ),
-      .data_in_rsp_o       ( tile_data_mst_rsp[i]     ),
+      .data_in_req_i       ( tile_data_mst_req[i] ),
+      .data_in_rsp_o       ( tile_data_mst_rsp[i] ),
 
-      .sync_if_o           ( sync_if[i]          ),
+      .sync_if_o           ( sync_if[i]           ),
       
-      .scan_cg_en_i        ( scan_cg_en          ),
+      .scan_cg_en_i        ( scan_cg_en           ),
 
-      .boot_addr_i         ( boot_addr           ),
-      .mtvec_addr_i        ( mtvec_addr          ),
-      .dm_halt_addr_i      ( dm_halt_addr        ),
-      .dm_exception_addr_i ( dm_exception_addr   ),
-      .mhartid_i           ( mhartid[i]          ),
-      .mimpid_patch_i      ( mimpid_patch        ),
+      .boot_addr_i         ( boot_addr            ),
+      .mtvec_addr_i        ( mtvec_addr           ),
+      .dm_halt_addr_i      ( dm_halt_addr         ),
+      .dm_exception_addr_i ( dm_exception_addr    ),
+      .mhartid_i           ( mhartid[i]           ),
+      .mimpid_patch_i      ( mimpid_patch         ),
 
-      .mcycle_o            ( mcycle[i]           ),
-      .time_i              ( time_var            ),
+      .mcycle_o            ( mcycle[i]            ),
+      .time_i              ( time_var             ),
 
-      .irq_i               ( irq                 ),
+      .irq_i               ( irq                  ),
 
-      .fencei_flush_req_o  ( fencei_flush_req[i] ),
-      .fencei_flush_ack_i  ( fencei_flush_ack    ),
+      .fencei_flush_req_o  ( fencei_flush_req[i]  ),
+      .fencei_flush_ack_i  ( fencei_flush_ack     ),
 
-      .debug_req_i         ( debug_req           ),
-      .debug_havereset_o   ( debug_havereset[i]  ),
-      .debug_running_o     ( debug_running[i]    ),
-      .debug_halted_o      ( debug_halted[i]     ),
-      .debug_pc_valid_o    ( debug_pc_valid[i]   ),
-      .debug_pc_o          ( debug_pc[i]         ),
+      .debug_req_i         ( debug_req            ),
+      .debug_havereset_o   ( debug_havereset[i]   ),
+      .debug_running_o     ( debug_running[i]     ),
+      .debug_halted_o      ( debug_halted[i]      ),
+      .debug_pc_valid_o    ( debug_pc_valid[i]    ),
+      .debug_pc_o          ( debug_pc[i]          ),
 
-      .fetch_enable_i      ( fetch_enable        ),
-      .core_sleep_o        ( core_sleep[i]       ),
-      .wu_wfe_i            ( wu_wfe              )
+      .fetch_enable_i      ( fetch_enable         ),
+      .core_sleep_o        ( core_sleep[i]        ),
+      .wu_wfe_i            ( wu_wfe               )
     );
 `ifdef CORE_TRACES
     localparam string core_trace_file_name = $sformatf("%s%0d", "log_file_", i);

--- a/target/src/mesh/redmule_mesh_fixture.sv
+++ b/target/src/mesh/redmule_mesh_fixture.sv
@@ -38,6 +38,12 @@ module redmule_mesh_fixture;
   redmule_mesh_pkg::axi_default_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_req;
   redmule_mesh_pkg::axi_default_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_rsp;
 
+  redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES:0] data_mst_req;
+  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES:0] data_mst_rsp;
+
+  redmule_tile_pkg::axi_xbar_slv_req_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_req;
+  redmule_tile_pkg::axi_xbar_slv_rsp_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_rsp;
+
   logic                                                                 scan_cg_en;
 
   logic[31:0]                                                           boot_addr;
@@ -69,11 +75,41 @@ module redmule_mesh_fixture;
 /*******************************************************/
 /**           Internal Signal Definitions End         **/
 /*******************************************************/
+/**                   AXI ID resize                   **/
+/*******************************************************/
+
+  for (genvar i = 0; i < redmule_mesh_tb_pkg::N_TILES; i++) begin: gen_iw_conv
+    axi_iw_converter #(
+      .AxiSlvPortIdWidth      ( redmule_mesh_tb_pkg::L2_ID_W          ),
+      .AxiMstPortIdWidth      ( redmule_tile_pkg::AXI_ID_W            ),
+      .AxiSlvPortMaxUniqIds   ( 32'd2                                 ),
+      .AxiSlvPortMaxTxnsPerId ( 32'd4                                 ),
+      .AxiSlvPortMaxTxns      ( 32'd16                                ),
+      .AxiMstPortMaxUniqIds   ( 32'd2                                 ),
+      .AxiMstPortMaxTxnsPerId ( 32'd4                                 ),
+      .AxiAddrWidth           ( redmule_mesh_pkg::ADDR_W              ),
+      .AxiDataWidth           ( redmule_mesh_pkg::DATA_W              ),
+      .AxiUserWidth           ( redmule_mesh_pkg::USR_W               ),
+      .slv_req_t              ( redmule_mesh_tb_pkg::axi_l2_vip_req_t ),
+      .slv_resp_t             ( redmule_mesh_tb_pkg::axi_l2_vip_rsp_t ),
+      .mst_req_t              ( redmule_tile_pkg::axi_xbar_slv_req_t  ),
+      .mst_resp_t             ( redmule_tile_pkg::axi_xbar_slv_rsp_t  )
+    ) i_axi_iw_converter (
+      .clk_i      ( clk                   ),
+      .rst_ni     ( rst_n                 ),
+      .slv_req_i  ( data_mst_req[i]       ),
+      .slv_resp_o ( data_mst_rsp[i]       ),
+      .mst_req_o  ( tile_data_mst_req[i]  ),
+      .mst_resp_i ( tile_data_mst_rsp[i]  )
+    );
+  end
+/*******************************************************/
 /**                   DUT Beginning                   **/
 /*******************************************************/
 
   for (genvar i = 0; i < redmule_mesh_tb_pkg::N_TILES; i++) begin: gen_tile
     redmule_tile #(
+      .TILE_ID      ( i                                 ),
       .N_MEM_BANKS  ( redmule_tile_tb_pkg::N_MEM_BANKS  ),
       .N_WORDS_BANK ( redmule_tile_tb_pkg::N_WORDS_BANK ),
 
@@ -88,7 +124,10 @@ module redmule_mesh_fixture;
       .tile_enable_i       ( tile_enable         ),
 
       .data_out_req_o      ( data_out_req[i]     ),
-      .data_out_rsp_i      ( data_out_rsp[i]     ), 
+      .data_out_rsp_i      ( data_out_rsp[i]     ),
+
+      .data_in_req_i       ( tile_data_mst_req[i]     ),
+      .data_in_rsp_o       ( tile_data_mst_rsp[i]     ),
 
       .scan_cg_en_i        ( scan_cg_en          ),
 

--- a/target/src/mesh/redmule_mesh_fixture.sv
+++ b/target/src/mesh/redmule_mesh_fixture.sv
@@ -44,7 +44,7 @@ module redmule_mesh_fixture;
   redmule_tile_pkg::axi_xbar_slv_req_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_req;
   redmule_tile_pkg::axi_xbar_slv_rsp_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_rsp;
 
-  fractal_if #(.LVL_WIDTH($clog2(redmule_mesh_tb_pkg::N_TILES)+1))      cu_if[redmule_mesh_tb_pkg::N_TILES]();
+  fractal_if #(.LVL_WIDTH($clog2(redmule_mesh_tb_pkg::N_TILES)+1))      sync_if[redmule_mesh_tb_pkg::N_TILES]();
   
   logic                                                                 scan_cg_en;
 
@@ -131,7 +131,7 @@ module redmule_mesh_fixture;
       .data_in_req_i       ( tile_data_mst_req[i]     ),
       .data_in_rsp_o       ( tile_data_mst_rsp[i]     ),
 
-      .cu_if_o             ( cu_if[i]            ),
+      .sync_if_o           ( sync_if[i]          ),
       
       .scan_cg_en_i        ( scan_cg_en          ),
 

--- a/target/src/mesh/redmule_mesh_fixture.sv
+++ b/target/src/mesh/redmule_mesh_fixture.sv
@@ -38,8 +38,8 @@ module redmule_mesh_fixture;
   redmule_mesh_pkg::axi_default_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_req;
   redmule_mesh_pkg::axi_default_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_rsp;
 
-  redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES:0] data_mst_req;
-  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES:0] data_mst_rsp;
+  redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_req;
+  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_rsp;
 
   redmule_tile_pkg::axi_xbar_slv_req_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_req;
   redmule_tile_pkg::axi_xbar_slv_rsp_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_rsp;
@@ -97,8 +97,8 @@ module redmule_mesh_fixture;
     ) i_axi_iw_converter (
       .clk_i      ( clk                   ),
       .rst_ni     ( rst_n                 ),
-      .slv_req_i  ( data_mst_req[i]       ),
-      .slv_resp_o ( data_mst_rsp[i]       ),
+      .slv_req_i  ( data_in_req[i]        ),
+      .slv_resp_o ( data_in_rsp[i]        ),
       .mst_req_o  ( tile_data_mst_req[i]  ),
       .mst_resp_i ( tile_data_mst_rsp[i]  )
     );

--- a/target/src/mesh/redmule_mesh_fixture.sv
+++ b/target/src/mesh/redmule_mesh_fixture.sv
@@ -38,8 +38,8 @@ module redmule_mesh_fixture;
   redmule_mesh_pkg::axi_default_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_req;
   redmule_mesh_pkg::axi_default_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_rsp;
 
-  redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES:0] data_mst_req;
-  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES:0] data_mst_rsp;
+  redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_req;
+  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_rsp;
 
   redmule_tile_pkg::axi_xbar_slv_req_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_req;
   redmule_tile_pkg::axi_xbar_slv_rsp_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_rsp;
@@ -99,8 +99,8 @@ module redmule_mesh_fixture;
     ) i_axi_iw_converter (
       .clk_i      ( clk                   ),
       .rst_ni     ( rst_n                 ),
-      .slv_req_i  ( data_mst_req[i]       ),
-      .slv_resp_o ( data_mst_rsp[i]       ),
+      .slv_req_i  ( data_in_req[i]        ),
+      .slv_resp_o ( data_in_rsp[i]        ),
       .mst_req_o  ( tile_data_mst_req[i]  ),
       .mst_resp_i ( tile_data_mst_rsp[i]  )
     );

--- a/target/src/mesh/redmule_mesh_fixture.sv
+++ b/target/src/mesh/redmule_mesh_fixture.sv
@@ -44,7 +44,7 @@ module redmule_mesh_fixture;
   redmule_tile_pkg::axi_xbar_slv_req_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_req;
   redmule_tile_pkg::axi_xbar_slv_rsp_t[redmule_mesh_tb_pkg::N_TILES:0]  tile_data_mst_rsp;
 
-  fractal_if #(.LVL_WIDTH($clog2(redmule_mesh_tb_pkg::N_TILES)+1))      sync_if[redmule_mesh_tb_pkg::N_TILES]();
+  fractal_if #(.LVL_WIDTH($clog2(redmule_mesh_tb_pkg::N_TILES)+1))      cu_if[redmule_mesh_tb_pkg::N_TILES]();
   
   logic                                                                 scan_cg_en;
 
@@ -131,7 +131,7 @@ module redmule_mesh_fixture;
       .data_in_req_i       ( tile_data_mst_req[i]     ),
       .data_in_rsp_o       ( tile_data_mst_rsp[i]     ),
 
-      .sync_if_o           ( sync_if[i]          ),
+      .cu_if_o             ( cu_if[i]            ),
       
       .scan_cg_en_i        ( scan_cg_en          ),
 

--- a/target/src/mesh/redmule_mesh_tb_pkg.sv
+++ b/target/src/mesh/redmule_mesh_tb_pkg.sv
@@ -25,7 +25,7 @@ package redmule_mesh_tb_pkg;
 
   parameter int unsigned N_MEM_BANKS  = 32;    // Number of memory banks 
   parameter int unsigned N_WORDS_BANK = 4096;  // Number of words per memory bank   
-  parameter int unsigned N_TILES      = 2;     // Number of tiles per mesh
+  parameter int unsigned N_TILES      = 4;     // Number of tiles per mesh
 
   parameter int unsigned L2_ID_W      = redmule_mesh_pkg::AXI_NOC_ID_W + $clog2(N_TILES);
   parameter int unsigned L2_U_W       = redmule_mesh_pkg::AXI_NOC_U_W;

--- a/target/src/mesh/redmule_mesh_vip.sv
+++ b/target/src/mesh/redmule_mesh_vip.sv
@@ -44,7 +44,7 @@ module redmule_mesh_vip
   output redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_req,
   input  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_rsp,
 
-  fractal_if.slv_port                                                          sync_if[redmule_mesh_tb_pkg::N_TILES],
+  fractal_if.slv_port                                                          cu_if[redmule_mesh_tb_pkg::N_TILES],
 
   output logic                                                                 scan_cg_en,
 
@@ -281,19 +281,37 @@ module redmule_mesh_vip
 /*******************************************************/
 /**         Synchronization Network Beginning         **/
 /*******************************************************/
+  localparam int unsigned LEVELS = 2;
+  localparam int unsigned CU_LVL_WIDTH = LEVELS + 1;
+  localparam int unsigned TOP_LVL_WIDTH = 2;
+  localparam int unsigned SYNC_PORTS = $clog2(redmule_mesh_tb_pkg::N_TILES);
 
-  //NOTE: The current VIP only support a synchronization network for 2 tiles
-
+  fractal_if #(.LVL_WIDTH(CU_LVL_WIDTH-1)) if_sync[SYNC_PORTS-1:0]();
   fractal_if #(.LVL_WIDTH(1)) if_top[1]();
 
-  fractal_sync #(
-    .SLV_WIDTH ( 2 )
-  ) i_fractal_sync (
-    .clk_i   ( clk     ),
-    .rstn_i  ( rst_n   ),
-    .slaves  ( sync_if ),
-    .masters ( if_top  )
-  );
+  // LEVEL 0 - tiles'
+  for (genvar i = 0; i < 2**(LEVELS-1); i++) begin: gen_cu_sync
+    fractal_sync #(
+      .SLV_WIDTH  ( CU_LVL_WIDTH  )
+    ) i_cu_fractal_sync (
+      .clk_i    ( clk                         ),
+      .rstn_i   ( rst_n                       ),
+      .slaves   ( '{cu_if[2*i], cu_if[2*i+1]} ),
+      .masters  ( '{if_sync[i]}               )
+    );
+  end
+
+  // LEVEL 1 - sync tree
+  for (genvar i = 0; i < 2**(LEVELS-2); i++) begin: gen_top_sync
+    fractal_sync #(
+      .SLV_WIDTH ( TOP_LVL_WIDTH  )
+    ) i_top_fractal_sync (
+      .clk_i    ( clk                             ),
+      .rstn_i   ( rst_n                           ),
+      .slaves   ( '{if_sync[2*i], if_sync[2*i+1]} ),
+      .masters  ( if_top                          )
+    );
+  end
 
   always begin
     if_top[0].wake  = 1'b0;

--- a/target/src/mesh/redmule_mesh_vip.sv
+++ b/target/src/mesh/redmule_mesh_vip.sv
@@ -33,46 +33,46 @@ module redmule_mesh_vip
   parameter real         T_APPL     = 0.1,
   parameter real         T_TEST     = 0.9
 )(
-  output logic                                                                 clk,
-  output logic                                                                 rst_n,
-  output logic                                                                 test_mode,
-  output logic                                                                 tile_enable,
+  output logic                                                                   clk,
+  output logic                                                                   rst_n,
+  output logic                                                                   test_mode,
+  output logic                                                                   tile_enable,
 
-  input  redmule_mesh_pkg::axi_default_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_req,
-  output redmule_mesh_pkg::axi_default_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_rsp,
+  input  redmule_mesh_pkg::axi_default_req_t[redmule_mesh_tb_pkg::N_TILES-1:0]   data_out_req,
+  output redmule_mesh_pkg::axi_default_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0]   data_out_rsp,
 
   output redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_req,
   input  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_rsp,
 
-  fractal_if.slv_port                                                          sync_if[redmule_mesh_tb_pkg::N_TILES],
+  fractal_if.slv_port                                                            sync_if[redmule_mesh_tb_pkg::N_TILES],
 
-  output logic                                                                 scan_cg_en,
+  output logic                                                                   scan_cg_en,
 
-  output logic[31:0]                                                           boot_addr, //TODO: manage signal
-  output logic[31:0]                                                           mtvec_addr,
-  output logic[31:0]                                                           dm_halt_addr,
-  output logic[31:0]                                                           dm_exception_addr,
-  output logic[31:0]                                                           mhartid[redmule_mesh_tb_pkg::N_TILES],
-  output logic[ 3:0]                                                           mimpid_patch,
+  output logic[31:0]                                                             boot_addr, //TODO: manage signal
+  output logic[31:0]                                                             mtvec_addr,
+  output logic[31:0]                                                             dm_halt_addr,
+  output logic[31:0]                                                             dm_exception_addr,
+  output logic[31:0]                                                             mhartid[redmule_mesh_tb_pkg::N_TILES],
+  output logic[ 3:0]                                                             mimpid_patch,
 
-  input  logic[63:0]                                                           mcycle[redmule_mesh_tb_pkg::N_TILES],
-  output logic[63:0]                                                           time_var,
+  input  logic[63:0]                                                             mcycle[redmule_mesh_tb_pkg::N_TILES],
+  output logic[63:0]                                                             time_var,
 
-  output logic[redmule_mesh_pkg::N_IRQ-1:0]                                    irq, //TODO: manage signal
+  output logic[redmule_mesh_pkg::N_IRQ-1:0]                                      irq, //TODO: manage signal
 
-  input  logic                                                                 fencei_flush_req[redmule_mesh_tb_pkg::N_TILES],
-  output logic                                                                 fencei_flush_ack,
+  input  logic                                                                   fencei_flush_req[redmule_mesh_tb_pkg::N_TILES],
+  output logic                                                                   fencei_flush_ack,
 
-  output logic                                                                 debug_req,
-  input  logic                                                                 debug_havereset[redmule_mesh_tb_pkg::N_TILES],
-  input  logic                                                                 debug_running[redmule_mesh_tb_pkg::N_TILES],
-  input  logic                                                                 debug_halted[redmule_mesh_tb_pkg::N_TILES],
-  input  logic                                                                 debug_pc_valid[redmule_mesh_tb_pkg::N_TILES],
-  input  logic[31:0]                                                           debug_pc[redmule_mesh_tb_pkg::N_TILES],
+  output logic                                                                   debug_req,
+  input  logic                                                                   debug_havereset[redmule_mesh_tb_pkg::N_TILES],
+  input  logic                                                                   debug_running[redmule_mesh_tb_pkg::N_TILES],
+  input  logic                                                                   debug_halted[redmule_mesh_tb_pkg::N_TILES],
+  input  logic                                                                   debug_pc_valid[redmule_mesh_tb_pkg::N_TILES],
+  input  logic[31:0]                                                             debug_pc[redmule_mesh_tb_pkg::N_TILES],
 
-  output logic                                                                 fetch_enable,  //TODO: manage signal
-  input  logic                                                                 core_sleep[redmule_mesh_tb_pkg::N_TILES],
-  output logic                                                                 wu_wfe
+  output logic                                                                   fetch_enable,  //TODO: manage signal
+  input  logic                                                                   core_sleep[redmule_mesh_tb_pkg::N_TILES],
+  output logic                                                                   wu_wfe
 );
 
 /*******************************************************/
@@ -203,24 +203,24 @@ module redmule_mesh_vip
     .ApplDelay          ( CLK_PERIOD * T_APPL                   ),
     .AcqDelay           ( CLK_PERIOD * T_TEST                   )
   ) i_l2_mem (
-    .clk_i              ( clk                                         ),
-    .rst_ni             ( rst_n                                       ),
-    .axi_req_i          ( data_mst_req[redmule_mesh_tb_pkg::N_TILES]  ),
-    .axi_rsp_o          ( data_mst_rsp[redmule_mesh_tb_pkg::N_TILES]  ),
-    .mon_w_valid_o      (              ),
-    .mon_w_addr_o       (              ),
-    .mon_w_data_o       (              ),
-    .mon_w_id_o         (              ),
-    .mon_w_user_o       (              ),
-    .mon_w_beat_count_o (              ),
-    .mon_w_last_o       (              ),
-    .mon_r_valid_o      (              ),
-    .mon_r_addr_o       (              ),
-    .mon_r_data_o       (              ),
-    .mon_r_id_o         (              ),
-    .mon_r_user_o       (              ),
-    .mon_r_beat_count_o (              ),
-    .mon_r_last_o       (              )
+    .clk_i              ( clk                                        ),
+    .rst_ni             ( rst_n                                      ),
+    .axi_req_i          ( data_mst_req[redmule_mesh_tb_pkg::N_TILES] ),
+    .axi_rsp_o          ( data_mst_rsp[redmule_mesh_tb_pkg::N_TILES] ),
+    .mon_w_valid_o      (                                            ),
+    .mon_w_addr_o       (                                            ),
+    .mon_w_data_o       (                                            ),
+    .mon_w_id_o         (                                            ),
+    .mon_w_user_o       (                                            ),
+    .mon_w_beat_count_o (                                            ),
+    .mon_w_last_o       (                                            ),
+    .mon_r_valid_o      (                                            ),
+    .mon_r_addr_o       (                                            ),
+    .mon_r_data_o       (                                            ),
+    .mon_r_id_o         (                                            ),
+    .mon_r_user_o       (                                            ),
+    .mon_r_beat_count_o (                                            ),
+    .mon_r_last_o       (                                            )
   );
 
 /*******************************************************/
@@ -229,20 +229,20 @@ module redmule_mesh_vip
 /**          Tiles - L2 (AXI XBAR) Beginning          **/
 /*******************************************************/
 
-  localparam int unsigned TILE_0_END_ADDR = redmule_tile_pkg::L1_ADDR_START + redmule_tile_pkg::L1_SIZE - 1;
+  localparam int unsigned TILE_0_END_ADDR   = redmule_tile_pkg::L1_ADDR_START + redmule_tile_pkg::L1_SIZE - 1;
   localparam int unsigned TILE_1_START_ADDR = redmule_tile_pkg::L1_ADDR_START + redmule_tile_pkg::L1_SIZE;
-  localparam int unsigned TILE_1_END_ADDR = TILE_0_END_ADDR + redmule_tile_pkg::L1_SIZE;
+  localparam int unsigned TILE_1_END_ADDR   = TILE_0_END_ADDR   + redmule_tile_pkg::L1_SIZE;
   localparam int unsigned TILE_2_START_ADDR = TILE_1_START_ADDR + redmule_tile_pkg::L1_SIZE;
-  localparam int unsigned TILE_2_END_ADDR = TILE_1_END_ADDR + redmule_tile_pkg::L1_SIZE;
+  localparam int unsigned TILE_2_END_ADDR   = TILE_1_END_ADDR   + redmule_tile_pkg::L1_SIZE;
   localparam int unsigned TILE_3_START_ADDR = TILE_2_START_ADDR + redmule_tile_pkg::L1_SIZE;
-  localparam int unsigned TILE_3_END_ADDR = TILE_2_END_ADDR + redmule_tile_pkg::L1_SIZE;
+  localparam int unsigned TILE_3_END_ADDR   = TILE_2_END_ADDR   + redmule_tile_pkg::L1_SIZE;
 
   localparam redmule_mesh_pkg::mesh_xbar_rule_t[redmule_mesh_pkg::mesh_xbar_cfg.NoAddrRules-1:0] MeshAxiAddrMap = '{
-    '{idx: 32'd0, start_addr: redmule_tile_pkg::L1_ADDR_START,  end_addr: TILE_0_END_ADDR               },
-    '{idx: 32'd1, start_addr: TILE_1_START_ADDR,                end_addr: TILE_1_END_ADDR               },
-    '{idx: 32'd2, start_addr: TILE_2_START_ADDR,                end_addr: TILE_2_END_ADDR               },
-    '{idx: 32'd3, start_addr: TILE_3_START_ADDR,                end_addr: TILE_3_END_ADDR               },
-    '{idx: 32'd4, start_addr: redmule_tile_pkg::L2_ADDR_START,  end_addr: redmule_tile_pkg::L2_ADDR_END }
+    '{idx: 32'd0, start_addr: redmule_tile_pkg::L1_ADDR_START, end_addr: TILE_0_END_ADDR               },
+    '{idx: 32'd1, start_addr: TILE_1_START_ADDR,               end_addr: TILE_1_END_ADDR               },
+    '{idx: 32'd2, start_addr: TILE_2_START_ADDR,               end_addr: TILE_2_END_ADDR               },
+    '{idx: 32'd3, start_addr: TILE_3_START_ADDR,               end_addr: TILE_3_END_ADDR               },
+    '{idx: 32'd4, start_addr: redmule_tile_pkg::L2_ADDR_START, end_addr: redmule_tile_pkg::L2_ADDR_END }
   };
 
   axi_xbar #(

--- a/target/src/mesh/redmule_mesh_vip.sv
+++ b/target/src/mesh/redmule_mesh_vip.sv
@@ -19,6 +19,8 @@
  * RedMulE Mesh Verification IP
  */
 
+ `include "axi/assign.svh"
+
 module redmule_mesh_vip
   import redmule_tile_pkg::*;
   import redmule_mesh_pkg::*;
@@ -38,6 +40,9 @@ module redmule_mesh_vip
 
   input  redmule_mesh_pkg::axi_default_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_req,
   output redmule_mesh_pkg::axi_default_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_rsp,
+
+  output redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_req,
+  input  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_rsp,
 
   output logic                                                                 scan_cg_en,
 
@@ -86,7 +91,20 @@ module redmule_mesh_vip
 /*******************************************************/
 /**          Internal Signal Definitions End          **/
 /*******************************************************/
-/**            Hardwired Signals Beginning            **/
+/**          Interface Assignments Beginning          **/
+/*******************************************************/
+
+  generate
+    for(genvar i=0; i<redmule_mesh_tb_pkg::N_TILES; i++) begin
+      /* assign data_in_req[i] = data_mst_req[i];
+      assign data_mst_rsp[i] = data_in_rsp[i]; */
+      `AXI_ASSIGN_REQ_STRUCT(data_in_req[i], data_mst_req[i])
+      `AXI_ASSIGN_RESP_STRUCT(data_mst_rsp[i], data_in_rsp[i])
+    end
+  endgenerate
+
+/*******************************************************/
+/**             Interface Assignments End             **/
 /*******************************************************/
 
   assign test_mode         = 1'b0;
@@ -220,8 +238,8 @@ module redmule_mesh_vip
   localparam redmule_mesh_pkg::mesh_xbar_rule_t[redmule_mesh_pkg::mesh_xbar_cfg.NoAddrRules-1:0] MeshAxiAddrMap = '{
     '{idx: 32'd0, start_addr: redmule_tile_pkg::L1_ADDR_START,  end_addr: TILE_0_END_ADDR               },
     '{idx: 32'd1, start_addr: TILE_1_START_ADDR,                end_addr: TILE_1_END_ADDR               },
-    '{idx: 32'd1, start_addr: TILE_2_START_ADDR,                end_addr: TILE_2_END_ADDR               },
-    '{idx: 32'd1, start_addr: TILE_3_START_ADDR,                end_addr: TILE_3_END_ADDR               },
+    '{idx: 32'd2, start_addr: TILE_2_START_ADDR,                end_addr: TILE_2_END_ADDR               },
+    '{idx: 32'd3, start_addr: TILE_3_START_ADDR,                end_addr: TILE_3_END_ADDR               },
     '{idx: 32'd4, start_addr: redmule_tile_pkg::L2_ADDR_START,  end_addr: redmule_tile_pkg::L2_ADDR_END }
   };
 

--- a/target/src/mesh/redmule_mesh_vip.sv
+++ b/target/src/mesh/redmule_mesh_vip.sv
@@ -80,8 +80,8 @@ module redmule_mesh_vip
 /**       Internal Signal Definitions Beginning       **/
 /*******************************************************/
 
-  redmule_mesh_tb_pkg::axi_l2_vip_req_t data_mst_req;
-  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t data_mst_rsp;
+  redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES:0] data_mst_req; // N_TILES + L2
+  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES:0] data_mst_rsp; // N_TILES + L2
 
 /*******************************************************/
 /**          Internal Signal Definitions End          **/
@@ -156,13 +156,13 @@ module redmule_mesh_vip
     while (!eoc) begin
       eoc = 1'b1;
       for (int i = 0; i < redmule_mesh_tb_pkg::N_TILES; i++)
-        if (i_l2_mem.mem[32'h2C03_0000 + i]  == 0)
+        if (i_l2_mem.mem[32'h5C03_0000 + i]  == 0)
           eoc = 1'b0;
       #10000;
     end
     
     for (int i = 0; i < redmule_mesh_tb_pkg::N_TILES; i++)
-      exit_code |= i_l2_mem.mem[32'h2C03_0000 + i] << i*8;
+      exit_code |= i_l2_mem.mem[32'h5C03_0000 + i] << i*8;
   endtask: wait_for_eoc
 
 /*******************************************************/
@@ -183,10 +183,10 @@ module redmule_mesh_vip
     .ApplDelay          ( CLK_PERIOD * T_APPL                   ),
     .AcqDelay           ( CLK_PERIOD * T_TEST                   )
   ) i_l2_mem (
-    .clk_i              ( clk          ),
-    .rst_ni             ( rst_n        ),
-    .axi_req_i          ( data_mst_req ),
-    .axi_rsp_o          ( data_mst_rsp ),
+    .clk_i              ( clk                                         ),
+    .rst_ni             ( rst_n                                       ),
+    .axi_req_i          ( data_mst_req[redmule_mesh_tb_pkg::N_TILES]  ),
+    .axi_rsp_o          ( data_mst_rsp[redmule_mesh_tb_pkg::N_TILES]  ),
     .mon_w_valid_o      (              ),
     .mon_w_addr_o       (              ),
     .mon_w_data_o       (              ),
@@ -209,37 +209,51 @@ module redmule_mesh_vip
 /**          Tiles - L2 (AXI XBAR) Beginning          **/
 /*******************************************************/
 
-  axi_mux #(
-    .SlvAxiIDWidth ( redmule_mesh_pkg::AXI_NOC_ID_W            ),
-    .slv_aw_chan_t ( redmule_mesh_pkg::axi_default_aw_chan_t   ),
-    .mst_aw_chan_t ( redmule_mesh_tb_pkg::axi_l2_vip_aw_chan_t ),
-    .w_chan_t      ( redmule_mesh_tb_pkg::axi_l2_vip_w_chan_t  ),
-    .slv_b_chan_t  ( redmule_mesh_pkg::axi_default_b_chan_t    ),
-    .mst_b_chan_t  ( redmule_mesh_tb_pkg::axi_l2_vip_b_chan_t  ),
-    .slv_ar_chan_t ( redmule_mesh_pkg::axi_default_ar_chan_t   ),
-    .mst_ar_chan_t ( redmule_mesh_tb_pkg::axi_l2_vip_ar_chan_t ),
-    .slv_r_chan_t  ( redmule_mesh_pkg::axi_default_r_chan_t    ),
-    .mst_r_chan_t  ( redmule_mesh_tb_pkg::axi_l2_vip_r_chan_t  ),
-    .slv_req_t     ( redmule_mesh_pkg::axi_default_req_t       ),
-    .slv_resp_t    ( redmule_mesh_pkg::axi_default_rsp_t       ),
-    .mst_req_t     ( redmule_mesh_tb_pkg::axi_l2_vip_req_t     ),
-    .mst_resp_t    ( redmule_mesh_tb_pkg::axi_l2_vip_rsp_t     ),
-    .NoSlvPorts    ( redmule_mesh_tb_pkg::N_TILES              ),
-    .MaxWTrans     ( redmule_tile_pkg::AxiXbarMaxWTrans*4      ),
-    .FallThrough   ( redmule_tile_pkg::AxiXbarFallThrough      ),
-    .SpillAw       ( redmule_tile_pkg::AxiXbarSpillAw          ),
-    .SpillW        ( redmule_tile_pkg::AxiXbarSpillW           ),
-    .SpillB        ( redmule_tile_pkg::AxiXbarSpillB           ),
-    .SpillAr       ( redmule_tile_pkg::AxiXbarSpillAr          ),
-    .SpillR        ( redmule_tile_pkg::AxiXbarSpillR           )
+  localparam int unsigned TILE_0_END_ADDR = redmule_tile_pkg::L1_ADDR_START + redmule_tile_pkg::L1_SIZE - 1;
+  localparam int unsigned TILE_1_START_ADDR = redmule_tile_pkg::L1_ADDR_START + redmule_tile_pkg::L1_SIZE;
+  localparam int unsigned TILE_1_END_ADDR = TILE_0_END_ADDR + redmule_tile_pkg::L1_SIZE;
+  localparam int unsigned TILE_2_START_ADDR = TILE_1_START_ADDR + redmule_tile_pkg::L1_SIZE;
+  localparam int unsigned TILE_2_END_ADDR = TILE_1_END_ADDR + redmule_tile_pkg::L1_SIZE;
+  localparam int unsigned TILE_3_START_ADDR = TILE_2_START_ADDR + redmule_tile_pkg::L1_SIZE;
+  localparam int unsigned TILE_3_END_ADDR = TILE_2_END_ADDR + redmule_tile_pkg::L1_SIZE;
+
+  localparam redmule_mesh_pkg::mesh_xbar_rule_t[redmule_mesh_pkg::mesh_xbar_cfg.NoAddrRules-1:0] MeshAxiAddrMap = '{
+    '{idx: 32'd0, start_addr: redmule_tile_pkg::L1_ADDR_START,  end_addr: TILE_0_END_ADDR               },
+    '{idx: 32'd1, start_addr: TILE_1_START_ADDR,                end_addr: TILE_1_END_ADDR               },
+    '{idx: 32'd1, start_addr: TILE_2_START_ADDR,                end_addr: TILE_2_END_ADDR               },
+    '{idx: 32'd1, start_addr: TILE_3_START_ADDR,                end_addr: TILE_3_END_ADDR               },
+    '{idx: 32'd4, start_addr: redmule_tile_pkg::L2_ADDR_START,  end_addr: redmule_tile_pkg::L2_ADDR_END }
+  };
+
+  axi_xbar #(
+    .Cfg            ( redmule_mesh_pkg::mesh_xbar_cfg             ),
+    .ATOPs          ( 1'b1                                        ),
+    .Connectivity   ( '1                                          ),
+    .slv_aw_chan_t  ( redmule_mesh_pkg::axi_default_aw_chan_t     ),
+    .mst_aw_chan_t  ( redmule_mesh_tb_pkg::axi_l2_vip_aw_chan_t   ),
+    .w_chan_t       ( redmule_mesh_tb_pkg::axi_l2_vip_w_chan_t    ),
+    .slv_b_chan_t   ( redmule_mesh_pkg::axi_default_b_chan_t      ),
+    .mst_b_chan_t   ( redmule_mesh_tb_pkg::axi_l2_vip_b_chan_t    ),
+    .slv_ar_chan_t  ( redmule_mesh_pkg::axi_default_ar_chan_t     ),
+    .mst_ar_chan_t  ( redmule_mesh_tb_pkg::axi_l2_vip_ar_chan_t   ),
+    .slv_r_chan_t   ( redmule_mesh_pkg::axi_default_r_chan_t      ),
+    .mst_r_chan_t   ( redmule_mesh_tb_pkg::axi_l2_vip_r_chan_t    ),
+    .slv_req_t      ( redmule_mesh_pkg::axi_default_req_t         ),
+    .mst_req_t      ( redmule_mesh_tb_pkg::axi_l2_vip_req_t       ),
+    .slv_resp_t     ( redmule_mesh_pkg::axi_default_rsp_t         ),
+    .mst_resp_t     ( redmule_mesh_tb_pkg::axi_l2_vip_rsp_t       ),
+    .rule_t         ( redmule_mesh_pkg::mesh_xbar_rule_t          )
   ) i_axi_xbar (
-    .clk_i       ( clk                   ),
-    .rst_ni      ( rst_n                 ),
-    .test_i      ( 1'b0                  ),
-    .slv_reqs_i  ( data_out_req          ),
-    .slv_resps_o ( data_out_rsp          ),
-    .mst_req_o   ( data_mst_req          ),
-    .mst_resp_i  ( data_mst_rsp          )   
+    .clk_i                  ( clk                   ),
+    .rst_ni                 ( rst_n                 ),
+    .test_i                 ( 1'b0                  ),
+    .slv_ports_req_i        ( data_out_req          ),
+    .slv_ports_resp_o       ( data_out_rsp          ),
+    .mst_ports_req_o        ( data_mst_req          ),
+    .mst_ports_resp_i       ( data_mst_rsp          ),
+    .addr_map_i             ( MeshAxiAddrMap        ),
+    .en_default_mst_port_i  ( '0                    ),
+    .default_mst_port_i     ( '0                    )
   );
 
 /*******************************************************/
@@ -260,20 +274,20 @@ module redmule_mesh_vip
     string_char_t chars[$];
     bit[redmule_mesh_tb_pkg::L2_ID_W-1:0] write_id;
     always @(posedge clk) begin: print_monitor
-      if ((gen_tile[i].dut.i_axi_xbar.mst_req_o.aw.addr == 32'h2FFF0000) && (gen_tile[i].dut.i_axi_xbar.mst_req_o.aw_valid))
+      if ((gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].aw.addr == 32'h5FFF0000) && (gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].aw_valid))
         stderr_ready = 1'b1;
-      if ((gen_tile[i].dut.i_axi_xbar.mst_req_o.aw.addr == 32'h2FFF0004+(i*4)) && (gen_tile[i].dut.i_axi_xbar.mst_req_o.aw_valid)) begin
+      if ((gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].aw.addr == 32'h5FFF0004+(i*4)) && (gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].aw_valid)) begin
         stdio_ready  = 1'b1;
-        write_id = gen_tile[i].dut.i_axi_xbar.mst_req_o.aw.id;
+        write_id = gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].aw.id;
       end
-      if ((gen_tile[i].dut.i_axi_xbar.mst_req_o.w_valid) && stderr_ready) begin
-        errors       = gen_tile[i].dut.i_axi_xbar.mst_req_o.w.data[7:0];
+      if ((gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].w_valid) && stderr_ready) begin
+        errors       = gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].w.data[7:0];
         stderr_ready = 1'b0;
       end
-      if ((gen_tile[i].dut.i_axi_xbar.mst_req_o.w_valid) && stdio_ready) begin
-        if (gen_tile[i].dut.i_axi_xbar.mst_req_o.w.data[7:0] == 10)  // ASCII code for new line (\n) is 10
+      if ((gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].w_valid) && stdio_ready) begin
+        if (gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].w.data[7:0] == 10)  // ASCII code for new line (\n) is 10
           print_line[write_id] = 1'b1;
-        chars.push_back('{gen_tile[i].dut.i_axi_xbar.mst_req_o.w.data[7:0], write_id});
+        chars.push_back('{gen_tile[i].dut.i_axi_xbar.mst_ports_req_o[0].w.data[7:0], write_id});
         stdio_ready = 1'b0;
       end
       for (int k = 0; k < 2**redmule_mesh_tb_pkg::L2_ID_W; k++) begin

--- a/target/src/mesh/redmule_mesh_vip.sv
+++ b/target/src/mesh/redmule_mesh_vip.sv
@@ -19,6 +19,8 @@
  * RedMulE Mesh Verification IP
  */
 
+ `include "axi/assign.svh"
+
 module redmule_mesh_vip
   import redmule_tile_pkg::*;
   import redmule_mesh_pkg::*;
@@ -39,8 +41,11 @@ module redmule_mesh_vip
   input  redmule_mesh_pkg::axi_default_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_req,
   output redmule_mesh_pkg::axi_default_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_out_rsp,
 
+  output redmule_mesh_tb_pkg::axi_l2_vip_req_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_req,
+  input  redmule_mesh_tb_pkg::axi_l2_vip_rsp_t[redmule_mesh_tb_pkg::N_TILES-1:0] data_in_rsp,
+
   fractal_if.slv_port                                                          sync_if[redmule_mesh_tb_pkg::N_TILES],
-  
+
   output logic                                                                 scan_cg_en,
 
   output logic[31:0]                                                           boot_addr, //TODO: manage signal
@@ -88,7 +93,20 @@ module redmule_mesh_vip
 /*******************************************************/
 /**          Internal Signal Definitions End          **/
 /*******************************************************/
-/**            Hardwired Signals Beginning            **/
+/**          Interface Assignments Beginning          **/
+/*******************************************************/
+
+  generate
+    for(genvar i=0; i<redmule_mesh_tb_pkg::N_TILES; i++) begin
+      /* assign data_in_req[i] = data_mst_req[i];
+      assign data_mst_rsp[i] = data_in_rsp[i]; */
+      `AXI_ASSIGN_REQ_STRUCT(data_in_req[i], data_mst_req[i])
+      `AXI_ASSIGN_RESP_STRUCT(data_mst_rsp[i], data_in_rsp[i])
+    end
+  endgenerate
+
+/*******************************************************/
+/**             Interface Assignments End             **/
 /*******************************************************/
 
   assign test_mode         = 1'b0;
@@ -222,8 +240,8 @@ module redmule_mesh_vip
   localparam redmule_mesh_pkg::mesh_xbar_rule_t[redmule_mesh_pkg::mesh_xbar_cfg.NoAddrRules-1:0] MeshAxiAddrMap = '{
     '{idx: 32'd0, start_addr: redmule_tile_pkg::L1_ADDR_START,  end_addr: TILE_0_END_ADDR               },
     '{idx: 32'd1, start_addr: TILE_1_START_ADDR,                end_addr: TILE_1_END_ADDR               },
-    '{idx: 32'd1, start_addr: TILE_2_START_ADDR,                end_addr: TILE_2_END_ADDR               },
-    '{idx: 32'd1, start_addr: TILE_3_START_ADDR,                end_addr: TILE_3_END_ADDR               },
+    '{idx: 32'd2, start_addr: TILE_2_START_ADDR,                end_addr: TILE_2_END_ADDR               },
+    '{idx: 32'd3, start_addr: TILE_3_START_ADDR,                end_addr: TILE_3_END_ADDR               },
     '{idx: 32'd4, start_addr: redmule_tile_pkg::L2_ADDR_START,  end_addr: redmule_tile_pkg::L2_ADDR_END }
   };
 

--- a/target/src/tile/redmule_tile_vip.sv
+++ b/target/src/tile/redmule_tile_vip.sv
@@ -140,9 +140,9 @@ module redmule_tile_vip
   endtask: elf_run
 
   task automatic wait_for_eoc(output bit[31:0] exit_code);
-    while (i_l2_mem.mem[32'h2C03_0000] == 0)
+    while (i_l2_mem.mem[32'h5C03_0000] == 0)
       #10000;
-    exit_code = i_l2_mem.mem[32'h2C03_0000];
+    exit_code = i_l2_mem.mem[32'h5C03_0000];
   endtask: wait_for_eoc
 
 /*******************************************************/
@@ -193,8 +193,8 @@ int errors = -1;
 bit stdio_ready  = 0;
 bit stderr_ready = 0;
 always @(posedge clk) begin: print_monitor
-  if ((data_out_req.aw.addr == 32'h2FFF0000) && (data_out_req.aw_valid)) stderr_ready = 1'b1;
-  if ((data_out_req.aw.addr == 32'h2FFF0004) && (data_out_req.aw_valid)) stdio_ready  = 1'b1;
+  if ((data_out_req.aw.addr == 32'h5FFF0000) && (data_out_req.aw_valid)) stderr_ready = 1'b1;
+  if ((data_out_req.aw.addr == 32'h5FFF0004) && (data_out_req.aw_valid)) stdio_ready  = 1'b1;
   if ((data_out_req.w_valid) && stderr_ready) begin
     // NOTE: This is stupid! But unless we keep track of the outstanding AXI writes (which would require some logic) this should work,
     //       unless other modules (not related to the print function) transfer bytes (instead of words) to the L2

--- a/target/src/tile/redmule_tile_vip.sv
+++ b/target/src/tile/redmule_tile_vip.sv
@@ -144,9 +144,9 @@ module redmule_tile_vip
   endtask: elf_run
 
   task automatic wait_for_eoc(output bit[31:0] exit_code);
-    while (i_l2_mem.mem[32'h2C03_0000] == 0)
+    while (i_l2_mem.mem[32'h5C03_0000] == 0)
       #10000;
-    exit_code = i_l2_mem.mem[32'h2C03_0000];
+    exit_code = i_l2_mem.mem[32'h5C03_0000];
   endtask: wait_for_eoc
 
 /*******************************************************/
@@ -197,8 +197,8 @@ int errors = -1;
 bit stdio_ready  = 0;
 bit stderr_ready = 0;
 always @(posedge clk) begin: print_monitor
-  if ((data_out_req.aw.addr == 32'h2FFF0000) && (data_out_req.aw_valid)) stderr_ready = 1'b1;
-  if ((data_out_req.aw.addr == 32'h2FFF0004) && (data_out_req.aw_valid)) stdio_ready  = 1'b1;
+  if ((data_out_req.aw.addr == 32'h5FFF0000) && (data_out_req.aw_valid)) stderr_ready = 1'b1;
+  if ((data_out_req.aw.addr == 32'h5FFF0004) && (data_out_req.aw_valid)) stdio_ready  = 1'b1;
   if ((data_out_req.w_valid) && stderr_ready) begin
     // NOTE: This is stupid! But unless we keep track of the outstanding AXI writes (which would require some logic) this should work,
     //       unless other modules (not related to the print function) transfer bytes (instead of words) to the L2


### PR DESCRIPTION
Mesh refactoring:
- added 2 more tiles
- enabled data transfer between the L1 of different tiles
- updated memory map in order to have different address ranges for the L1 memories of different tiles
- updated software tests
- moved stack from L2 to L1
- created an alias region for the stack