### PR TITLE
[CI]: Activating CI for PRs coming from external forks

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -13,6 +13,9 @@ on:
   pull_request_target:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # Internal PRs and pushes: run directly with secrets available.
   gitlab-ci-internal:


### PR DESCRIPTION
Changed `gitlab-ci.yml` to enable CI also fro PRs coming from forks outside the pulp-platform organization. Manual approval by a mainainer is required to trigger the CI pipeline.