### PR TITLE
Fix tile elaboration after NW bump

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -152,11 +152,11 @@ sources:
   - target: all(not(magia_dv), asic)
     files:
       # NoC
-      - hw/mesh/noc/floo_axi_mesh_2x2_noc.sv
-      - hw/mesh/noc/floo_axi_mesh_4x4_noc.sv
-      - hw/mesh/noc/floo_axi_mesh_8x8_noc.sv
-      - hw/mesh/noc/floo_axi_mesh_16x16_noc.sv
-      - hw/mesh/noc/floo_axi_mesh_32x32_noc.sv
+      - hw/mesh/noc/floo_axi_nw_mesh_2x2_noc.sv
+      - hw/mesh/noc/floo_axi_nw_mesh_4x4_noc.sv
+      - hw/mesh/noc/floo_axi_nw_mesh_8x8_noc.sv
+      - hw/mesh/noc/floo_axi_nw_mesh_16x16_noc.sv
+      - hw/mesh/noc/floo_axi_nw_mesh_32x32_noc.sv
       # MAGIA Packages
       - hw/mesh/magia_pkg.sv
       - hw/tile/magia_tile_pkg.sv
@@ -191,11 +191,6 @@ sources:
       - hw/tile/magia_redmule_wrap.sv
       - hw/tile/magia_tile.sv
       # MAGIA
-      - hw/mesh/noc/floo_axi_nw_mesh_2x2_noc.sv
-      - hw/mesh/noc/floo_axi_nw_mesh_4x4_noc.sv
-      - hw/mesh/noc/floo_axi_nw_mesh_8x8_noc.sv
-      - hw/mesh/noc/floo_axi_nw_mesh_16x16_noc.sv
-      - hw/mesh/noc/floo_axi_nw_mesh_32x32_noc.sv
       - hw/mesh/magia.sv
       # Tech
       - pd/sourcecode/tc_sram.sv

--- a/hw/tile/magia_tile.sv
+++ b/hw/tile/magia_tile.sv
@@ -898,7 +898,13 @@ module magia_tile
     EW:  hci_package::DEFAULT_EW,
     EHW: hci_package::DEFAULT_EHW
   };
-  `HCI_INTF_ARRAY(hci_ext_if, sys_clk, 0:magia_tile_pkg::N_EXT-1);
+  generate;
+    if (N_EXT > 0) begin
+      `HCI_INTF_ARRAY(hci_ext_if, sys_clk, 0:magia_tile_pkg::N_EXT-1);
+    end else if (N_EXT == 0) begin
+      `HCI_INTF_ARRAY(hci_ext_if, sys_clk, 0:0);
+    end
+  endgenerate
 
   cv32e40x_if_xif xif_redmule_if ();
 


### PR DESCRIPTION
- Removed old FlooNoC files from synth target in `Bender.yml`
- Added a workaround within `magia_tile.sv` to manage the range selection in `HCI_INTF_ARRAY` macro in the case of `N_EXT=0` to avoid underflow of the index