### PR TITLE
Resizing of RedMulE in a 8x8 CEs matrix (1 Pipe Stage)  (Added also assertion to check DW)

### DIFF
--- a/hw/tile/magia_redmule_wrap.sv
+++ b/hw/tile/magia_redmule_wrap.sv
@@ -35,8 +35,8 @@ module magia_redmule_wrap
 #(
   parameter int unsigned  DataW                  = magia_tile_pkg::REDMULE_DW,
   parameter fp_format_e   FpFormat               = FP16,
-  parameter int unsigned  Height                 = 16,
-  parameter int unsigned  Width                  = 24,            // fixme: possibly decrease to 16
+  parameter int unsigned  Height                 = 8,
+  parameter int unsigned  Width                  = 8,
   parameter int unsigned  NumPipeRegs            = 1,
   parameter pipe_config_t PipeConfig             = DISTRIBUTED,
   parameter int unsigned  EccChunkSize           = 32,
@@ -225,5 +225,20 @@ module magia_redmule_wrap
     .tcdm                ( tcdm                ),
     .target              ( target              )
   );
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Assertions
+  /////////////////////////////////////////////////////////////////////////////
+
+  `ifndef SYNTHESIS
+  // RedMulE expects: DataW = Height × (NumPipeRegs + 1) × fp_width(FpFormat)
+  localparam int unsigned EXPECTED_DATAW = Height * (NumPipeRegs + 1) * fpnew_pkg::fp_width(FpFormat);
+    initial begin
+      if (DataW != EXPECTED_DATAW) begin
+        $error("[REDMULE_WRAP] DataW parameter mismatch! Expected %0d (Height=%0d x (NumPipeRegs=%0d + 1) x fp_width(%s)=%0d), got %0d", 
+               EXPECTED_DATAW, Height, NumPipeRegs, FpFormat.name(), fpnew_pkg::fp_width(FpFormat), DataW);
+      end
+    end
+  `endif
 
 endmodule

--- a/hw/tile/magia_tile.sv
+++ b/hw/tile/magia_tile.sv
@@ -1026,10 +1026,13 @@ module magia_tile
   magia_redmule_wrap #(
 `ifdef CV32E40X
     .CtrlIntfConfig  ( redmule_pkg::XIF            ),
+    .XifIdWidth      ( magia_tile_pkg::X_ID_W      ),
 `else
     .CtrlIntfConfig  ( redmule_pkg::HWPE_TARGET    ),
 `endif
-    .XifIdWidth      ( magia_tile_pkg::X_ID_W      )
+    .Height          ( magia_tile_pkg::REDMULE_HEIGHT    ),
+    .Width           ( magia_tile_pkg::REDMULE_WIDTH     ),
+    .NumPipeRegs     ( magia_tile_pkg::REDMULE_NUM_PIPE_REGS )
   ) i_redmule_wrap (
     .clk_i               ( sys_clk                                                     ),
     .rst_ni              ( rst_ni                                                      ),

--- a/hw/tile/magia_tile_pkg.sv
+++ b/hw/tile/magia_tile_pkg.sv
@@ -243,7 +243,7 @@ package magia_tile_pkg;
   parameter int unsigned TS_BIT  = 21;                                                  // TEST_SET_BIT (for Log Interconnect)
   parameter int unsigned IW      = N_HWPE+N_CORE+N_DMA+N_EXT;                           // ID Width HCI
   parameter int unsigned EXPFIFO = 0;                                                   // FIFO Depth for HWPE Interconnect
-  parameter int unsigned DWH     = 544;                                                 // Data Width for HWPE Interconnect: RedMulE Hx(P+1)xBits + Bank width for misaligned access = 8x(3+1)x16+32 
+  parameter int unsigned DWH     = 288;                                                 // Data Width for HWPE Interconnect: RedMulE Hx(P+1)xBits + Bank width for misaligned
   parameter int unsigned AWH     = magia_pkg::ADDR_W;                                   // Address Width for HWPE Interconnect
   parameter int unsigned BWH     = magia_pkg::BYTE_W;                                   // Byte Width for HWPE Interconnect
   parameter int unsigned WWH     = DWH;                                                 // Word Width for HWPE Interconnect
@@ -299,6 +299,9 @@ package magia_tile_pkg;
   parameter int unsigned EVENT_UNIT_IRQ_WIDTH = 5;                                      // Width of Event Unit IRQ ID signals (supports up to 32 different event types)
 
   // Parameters used by RedMulE
+  parameter int unsigned REDMULE_HEIGHT          = 8;                                   // RedMulE systolic array height
+  parameter int unsigned REDMULE_WIDTH           = 8;                                   // RedMulE systolic array width
+  parameter int unsigned REDMULE_NUM_PIPE_REGS   = 1;                                   // RedMulE pipeline registers
   parameter int unsigned REDMULE_DW         = DWH-32;                                   // RedMulE Data Width 
   parameter int unsigned REDMULE_ID_W       = magia_pkg::ID_W + 
                                               magia_pkg::ID_W_OFFSET;                   // RedMulE ID Width


### PR DESCRIPTION
## Overview
This PR resizes the RedMulE systolic array from a 16x24 configuration to a 8x8 configuration, and adds assertion to ensure parameter consistency.

## Changes

### RedMulE Configuration
- Reduced systolic array dimensions from **16×24** to **8×8**
- Updated `Height` and `Width` parameters in `magia_redmule_wrap.sv`
- Added centralized parameters in `magia_tile_pkg.sv`:
  - `REDMULE_HEIGHT = 8`
  - `REDMULE_WIDTH = 8`
  - `REDMULE_NUM_PIPE_REGS = 1`

### Data Width Adjustment
- Updated `DWH` (HWPE Interconnect Data Width) from **544 bits** to **288 bits**

### Parameter Validation
- Added assertion in `magia_redmule_wrap.sv` to verify:
DataW == Height × (NumPipeRegs + 1) × fp_width(FpFormat)

### Parameterization
- RedMulE instantiation in `magia_tile.sv` is parametrized by passing `Height`, `Width`, and `NumPipeRegs` from the package
