### PR TITLE
Pin setuptools in Python dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ python_venv:
 	$(BASE_PYTHON) -m venv magia_venv
 
 python_deps:
-	$(BASE_PYTHON) -m pip install --upgrade pip setuptools && \
+	$(BASE_PYTHON) -m pip install --upgrade pip && \
     $(BASE_PYTHON) -m pip install -r requirements.txt
 
 # Generate instructions and data stimuli

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: SHL-0.51
 
 flatdict
+setuptools<79
 pyyaml
 mako
 hjson


### PR DESCRIPTION
Fixes #45.

Summary:
- move setuptools management into requirements.txt with a <79 upper bound
- stop make python_deps from upgrading setuptools outside the declared requirements
- keep the existing pip upgrade behavior before installing project Python dependencies

Validation:
- Not run locally.