### PR TITLE
Update redmule and hwpe-ctrl in Bender.yml

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -24,13 +24,13 @@ package:
     - "Luca Balboni (luca.balboni10@studio.unibo.it)"
 
 dependencies:
-  redmule           : { git: "https://github.com/pulp-platform/redmule.git"           , rev: 944d4a4d45fe05147cfbf7f872af677578f3b15c } # branch: fc/ooo-mux
+  redmule           : { git: "https://github.com/pulp-platform/redmule.git"           , version: 2.1.0                                }
   cv32e40x          : { git: "https://github.com/pulp-platform/cv32e40x.git"          , rev: a90101211048ba1a16cedbe4db963ab6e12569d7 } # branch: vi/redmule_scaleup
   cv32e40p          : { git: "https://github.com/FondazioneChipsIT/cv32e40p.git"      , rev: a8206ab02759f110c40dd907369816ea656381bc } # branch: ng/pulp_cluster
   spatz             : { git: "https://github.com/pulp-platform/spatz.git"             , rev: 9380883fd36a4794d7f31e2c22e3fed3202aeb81 } # branch: lb/magia-spatz_cc
   idma              : { git: "https://github.com/pulp-platform/iDMA.git"              , rev: ff5d56fffb3767814db88d6bf8f381974ea33aa5 } # version: 0.6.4
   hwpe-stream       : { git: "https://github.com/pulp-platform/hwpe-stream.git"       , version: 1.6                                  }
-  hwpe-ctrl         : { git: "https://github.com/pulp-platform/hwpe-ctrl.git"         , rev: ce04de5fc48df0d536cae32301ccd83d93c05430 } # v3.0.0 (OBI target iface, matches redmule fc/ooo-mux); 
+  hwpe-ctrl         : { git: "https://github.com/pulp-platform/hwpe-ctrl.git"         , version: 3.1.0                                } 
   hci               : { git: "https://github.com/pulp-platform/hci.git"               , version: 2.3.0                                }
   cluster_icache    : { git: "https://github.com/pulp-platform/cluster_icache.git"    , version: 0.2.0                                }
   fpnew             : { git: "https://github.com/pulp-platform/cvfpu.git"             , rev: "pulp-v0.1.3"                            }


### PR DESCRIPTION
Don't we push Bender.lock? This updates RedMulE to `v2.1.0`, which is tested under many conditions of `M`, `N`, `K` sizes including leftovers, very small sizes etc.; it includes an updated `hwpe-ctrl` aligned with recent changes in `magia-sdk`; it is regression-tested with a Verilator-based CI running entirely on GitHub.