### PR TITLE
CI on UNIBO premises

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -22,8 +22,8 @@ jobs:
         # Skip on forks or pull requests from forks due to missing secrets.
         if: github.repository == 'pulp-platform/MAGIA' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
-          domain: iis-git.ee.ethz.ch
-          repo: github-mirror/magia
-          token: ${{ secrets.GITLAB_TOKEN }}
+          domain: ${{ secrets.GITLAB_UNIBO_SERVER }}
+          repo: github-mirror/MAGIA
+          token: ${{ secrets.GITLAB_UNIBO_TOKEN }}
           poll-count: 1000
           poll-period: 60

--- a/Bender.yml
+++ b/Bender.yml
@@ -233,6 +233,7 @@ sources:
       - hw/tile/spatz_cc_wrapper.sv
       - hw/tile/core_data_demux_eu_direct.sv
       - hw/tile/eu_direct_cut.sv
+      - hw/tile/magia_tile_icache_wrap.sv
       - hw/tile/magia_redmule_wrap.sv
       - hw/tile/magia_tile.sv
       # MAGIA

--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ ifeq ($(core), RI5CY)
 else
 	@sed -i '/^  cv32e40p:$$/,/^  cv32e40x:/ { s|^    revision: .*|    revision: $(CV32E40P_REV)|; 			s|^      Git: .*|      Git: $(CV32E40P_GIT)|; 		}' Bender.lock
 endif
-	$(BENDER) update
+	$(BENDER) checkout
 	$(BENDER) script vsim          \
 	--vlog-arg="$(compile_flag)"   \
 	--vcom-arg="-pedanticerrors"   \
@@ -571,9 +571,9 @@ hw-clean:
 hw-all: hw-clean hw-lib hw-compile hw-opt
 
 # Nonfree components
-MAGIA_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/magia-nonfree
+MAGIA_NONFREE_REMOTE ?= $(GITLAB_UNIBO_SSH_STRING)/magia/nonfree.git
 MAGIA_NONFREE_DIR ?= nonfree
-MAGIA_NONFREE_COMMIT ?= 825ec37e40a1b46749cbcd59ff77f75d7a8f0296
+MAGIA_NONFREE_COMMIT ?= 80125ef82668544234d2f2783a845c70349a3e8c
 
 .PHONY: magia-nonfree-init
 MAGIA_NONFREE_DEPS ?= 1

--- a/Makefile
+++ b/Makefile
@@ -572,11 +572,12 @@ hw-all: hw-clean hw-lib hw-compile hw-opt
 
 # Nonfree components
 MAGIA_NONFREE_REMOTE ?= $(GITLAB_UNIBO_SSH_STRING)/magia/nonfree.git
-MAGIA_NONFREE_DIR ?= nonfree
-MAGIA_NONFREE_COMMIT ?= 80125ef82668544234d2f2783a845c70349a3e8c
+MAGIA_NONFREE_DIR    ?= nonfree
+MAGIA_NONFREE_COMMIT ?= 85b1df9cedbe7a52a361c05fea9181e084e2b4c8
+MAGIA_NONFREE_DEPS   ?= 1
 
 .PHONY: magia-nonfree-init
-MAGIA_NONFREE_DEPS ?= 1
+
 magia-nonfree-init:
 	git clone $(MAGIA_NONFREE_REMOTE) $(MAGIA_NONFREE_DIR)
 	cd $(MAGIA_NONFREE_DIR) && git checkout $(MAGIA_NONFREE_COMMIT)


### PR DESCRIPTION
This PR moves CI to local UNIBO premises in place of shared IIS runners.
It also removes regressions running on ri5cy.