### PR TITLE
[HOTFIX]: Bumped RedMulE to solve issues with automatic re-triggering

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -144,8 +144,8 @@ packages:
     - redundancy_cells
     - register_interface
   hwpe-ctrl:
-    revision: a52dc9cd2a5a8bb68fbf7e445bf51ac5e2e3cade
-    version: 3.1.0
+    revision: dfcf1cb746709de206377388bbcb4a3571e24f7b
+    version: 3.1.1
     source:
       Git: https://github.com/pulp-platform/hwpe-ctrl.git
     dependencies:
@@ -192,8 +192,8 @@ packages:
     - common_cells
     - common_verification
   redmule:
-    revision: 4c7bdf3c46483780c6f2e18f833be2ea664af36c
-    version: 2.1.0
+    revision: 7fa9fbe8a29e8572810ae12b92c19749045ac860
+    version: 2.2.0
     source:
       Git: https://github.com/pulp-platform/redmule.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -24,13 +24,13 @@ package:
     - "Luca Balboni (luca.balboni10@studio.unibo.it)"
 
 dependencies:
-  redmule           : { git: "https://github.com/pulp-platform/redmule.git"           , version: 2.1.0                                }
+  redmule           : { git: "https://github.com/pulp-platform/redmule.git"           , rev: 2.2.0                                    }
   cv32e40x          : { git: "https://github.com/pulp-platform/cv32e40x.git"          , rev: a90101211048ba1a16cedbe4db963ab6e12569d7 } # branch: vi/redmule_scaleup
   cv32e40p          : { git: "https://github.com/FondazioneChipsIT/cv32e40p.git"      , rev: a8206ab02759f110c40dd907369816ea656381bc } # branch: ng/pulp_cluster
   spatz             : { git: "https://github.com/pulp-platform/spatz.git"             , rev: 9380883fd36a4794d7f31e2c22e3fed3202aeb81 } # branch: lb/magia-spatz_cc
   idma              : { git: "https://github.com/pulp-platform/iDMA.git"              , rev: ff5d56fffb3767814db88d6bf8f381974ea33aa5 } # version: 0.6.4
   hwpe-stream       : { git: "https://github.com/pulp-platform/hwpe-stream.git"       , version: 1.6                                  }
-  hwpe-ctrl         : { git: "https://github.com/pulp-platform/hwpe-ctrl.git"         , version: 3.1.0                                } 
+  hwpe-ctrl         : { git: "https://github.com/pulp-platform/hwpe-ctrl.git"         , version: 3.1.1                                }
   hci               : { git: "https://github.com/pulp-platform/hci.git"               , version: 2.3.0                                }
   cluster_icache    : { git: "https://github.com/pulp-platform/cluster_icache.git"    , version: 0.2.0                                }
   fpnew             : { git: "https://github.com/pulp-platform/cvfpu.git"             , rev: "pulp-v0.1.3"                            }


### PR DESCRIPTION
Bumped RedMulE submodule to solve an issue related to the automatic re-triggering of queued jobs: the accelerator was automatically triggering a new job at the end of the output stream, even when the job FIFO was empty.