### PR TITLE
Use verilator for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -573,7 +573,7 @@ hw-all: hw-clean hw-lib hw-compile hw-opt
 # Nonfree components
 MAGIA_NONFREE_REMOTE ?= $(GITLAB_UNIBO_SSH_STRING)/magia/nonfree.git
 MAGIA_NONFREE_DIR    ?= nonfree
-MAGIA_NONFREE_COMMIT ?= 44cefe806e5c6ebf25d2d2ad196c28fdb59493c2
+MAGIA_NONFREE_COMMIT ?= 835eadd2ca4e585498c3aef743b21acda59d7414
 MAGIA_NONFREE_DEPS   ?= 1
 
 .PHONY: magia-nonfree-init

--- a/Makefile
+++ b/Makefile
@@ -573,7 +573,7 @@ hw-all: hw-clean hw-lib hw-compile hw-opt
 # Nonfree components
 MAGIA_NONFREE_REMOTE ?= $(GITLAB_UNIBO_SSH_STRING)/magia/nonfree.git
 MAGIA_NONFREE_DIR    ?= nonfree
-MAGIA_NONFREE_COMMIT ?= 85b1df9cedbe7a52a361c05fea9181e084e2b4c8
+MAGIA_NONFREE_COMMIT ?= 44cefe806e5c6ebf25d2d2ad196c28fdb59493c2
 MAGIA_NONFREE_DEPS   ?= 1
 
 .PHONY: magia-nonfree-init

--- a/scripts/sim_ret_errors_verilator.sh
+++ b/scripts/sim_ret_errors_verilator.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE.SHL for details.
+# SPDX-License-Identifier: SHL-0.51
+
+# Verilator counterpart of sim_ret_errors.sh. QuestaSim prints an "Errors: N"
+# summary; Verilator prints nothing of the sort, so the verdict comes from the
+# testbench's own end-of-simulation line instead.
+#
+# The process exit code is not enough on its own: magia_main.cpp also returns 0
+# when the model simply runs out of events without reaching $finish, which is
+# what a hung or wedged simulation looks like. So a missing line is its own
+# outcome rather than a pass.
+#
+#   0  simulation finished with exit code 0
+#   1  simulation finished with a non-zero exit code, or Verilator errored out
+#   2  log file not found
+#   3  no end-of-simulation line at all (never reached $finish: hung, killed,
+#      or the model died before the testbench could report)
+
+LOGFILE="$1"
+
+if [[ ! -f "$LOGFILE" ]]; then
+  echo "Error: File not found!"
+  exit 2
+fi
+
+# Last occurrence wins, matching sim_ret_errors.sh.
+code=$(grep -oP 'SIMULATION FINISHED WITH EXIT CODE:\s*\K[0-9a-fA-F]+' "$LOGFILE" | tail -n 1)
+
+if [[ -z "$code" ]]; then
+  echo "No 'SIMULATION FINISHED WITH EXIT CODE' line found in log file."
+  exit 3
+fi
+
+# The testbench prints the code with %0h.
+if (( 16#$code != 0 )); then
+  echo "Simulation finished with exit code 0x$code."
+  exit 1
+fi
+
+# $fatal aborts before the success line, so reaching here with a Verilator error
+# in the log means something else failed after end-of-simulation.
+if grep -q '^%Error' "$LOGFILE"; then
+  echo "Simulation reported exit code 0 but the log contains Verilator errors."
+  exit 1
+fi
+
+exit 0

--- a/verilator/scripts/filter_filelist.py
+++ b/verilator/scripts/filter_filelist.py
@@ -17,6 +17,11 @@ EXCLUDED = {
     # child-block parsing does not lazily skip it and hits an unsupported
     # `##[min:max]` cycle-delay-range assertion (Plan 3, Step 6).
     "snitch_icache_l0_tb.sv",
+    # iDMA's own backend testbenches, one module per backend ID. Nothing in
+    # magia_tb instantiates them, and they are the only files in the flist that
+    # need a tracer macro for an ID outside iDMA's stock set -- the rest use
+    # `IDMA_TRACER_RW_AXI, which the checked-in header always defines.
+    "tb_idma_generated.sv",
 }
 
 


### PR DESCRIPTION
This commit modifies nonfree so that CI runs first on Verilator and then (only if Verilator passes) on QuestaSim. This is primarily to save license resources from being overused.